### PR TITLE
TraefikEtcdProxy and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_install:
 install:
   - pip install --pre -r dev-requirements.txt .
   - pip install pytest-travis-fold
-  - pip install requests
-  - pip install etcd3
-  - pip install asyncio
   - wget https://github.com/containous/traefik/releases/download/v1.7.0/traefik_linux-amd64
   - sudo chmod +x traefik_linux-amd64
   - sudo ln -s -T `pwd`/traefik_linux-amd64 /usr/local/bin/traefik

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ install:
 
 # running tests
 script:
-  - pytest -v -s
+  - pytest -v
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ install:
 
 # running tests
 script:
-  - pytest -v
+  - pytest -v -s
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 env:
   global:
     - ASYNC_TEST_TIMEOUT=15
+    - ETCDCTL_API=3
 
 # installing dependencies
 before_install:
@@ -14,7 +15,17 @@ before_install:
   - pip install --pre -r dev-requirements.txt
 install:
   - pip install --pre -r dev-requirements.txt .
-  # TODO: setup etcd
+  - pip install pytest-travis-fold
+  - pip install requests
+  - pip install etcd3
+  - pip install asyncio
+  - wget https://github.com/containous/traefik/releases/download/v1.7.0/traefik_linux-amd64
+  - sudo chmod +x traefik_linux-amd64
+  - sudo ln -s -T `pwd`/traefik_linux-amd64 /usr/local/bin/traefik
+  - ls -l /usr/local/bin
+  - wget https://github.com/etcd-io/etcd/releases/download/v3.3.10/etcd-v3.3.10-linux-amd64.tar.gz
+  - tar xzvf etcd-v3.3.10-linux-amd64.tar.gz
+  - ./etcd-v3.3.10-linux-amd64/etcd &
   - pip freeze
 
 # running tests
@@ -22,4 +33,3 @@ script:
   - pytest -v
 after_success:
   - codecov
-

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,6 @@
 pytest
 pytest-asyncio
+etcd3
+requests
 codecov
 black

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -14,3 +14,9 @@ Module: :mod:`jupyterhub_traefik_proxy`
 
 .. autoconfigurable:: TraefikProxy
     :members:
+
+:class:`TraefikEtcdProxy`
+---------------------
+
+.. autoconfigurable:: TraefikEtcdProxy
+    :members:

--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -7,6 +7,6 @@ so you don't have to worry about code formatting.
 
 Install it with:
 
-./hooks/install
+./git-hooks/install
 
 from the root of the repo.

--- a/jupyterhub_traefik_proxy/__init__.py
+++ b/jupyterhub_traefik_proxy/__init__.py
@@ -1,6 +1,7 @@
 """Traefik implementation of the JupyterHub proxy API"""
 
 from .proxy import TraefikProxy  # noqa
+from .etcd import TraefikEtcdProxy
 
 from ._version import get_versions
 

--- a/jupyterhub_traefik_proxy/dummy_http_server.py
+++ b/jupyterhub_traefik_proxy/dummy_http_server.py
@@ -1,0 +1,33 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class DummyServer(BaseHTTPRequestHandler):
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+    def do_GET(self):
+        self._set_headers()
+        self.wfile.write(bytes(str(self.server.server_port), "utf-8"))
+
+
+def run(port=80):
+    dummy_server = HTTPServer(("localhost", port), DummyServer)
+    print("Starting dummy server...")
+
+    try:
+        dummy_server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    dummy_server.server_close()
+
+
+if __name__ == "__main__":
+    from sys import argv
+
+    if len(argv) == 2:
+        run(port=int(argv[1]))
+    else:
+        run()

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -1,0 +1,271 @@
+"""Traefik implementation
+
+Custom proxy implementations can subclass :class:`Proxy`
+and register in JupyterHub config:
+
+.. sourcecode:: python
+
+    from mymodule import MyProxy
+    c.JupyterHub.proxy_class = MyProxy
+
+Route Specification:
+
+- A routespec is a URL prefix ([host]/path/), e.g.
+  'host.tld/path/' for host-based routing or '/path/' for default routing.
+- Route paths should be normalized to always start and end with '/'
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import asyncio
+import json
+import etcd3
+import os
+
+from subprocess import Popen
+
+from traitlets import Any, Unicode
+
+from jupyterhub.proxy import Proxy
+
+from . import traefik_utils
+
+
+class TraefikEtcdProxy(Proxy):
+    """JupyterHub Proxy implementation using traefik and etcd"""
+
+    traefik_process = Any()
+    client = etcd3.client("127.0.0.1", 2379)
+
+    command = "traefik"
+    traefik_port = traefik_utils.get_port(command)
+
+    def _setup_etcd(self):
+        self.log.info("Seting up etcd...")
+        self.client.put(traefik_utils.traefik_prefix + "/debug", "true")
+        self.client.put(traefik_utils.traefik_prefix + "/defaultentrypoints/0", "http")
+        self.client.put(
+            traefik_utils.traefik_prefix + "/entrypoints/http/address",
+            ":" + str(self.traefik_port),
+        )
+        self.client.put(traefik_utils.traefik_prefix + "/api/dashboard", "true")
+        self.client.put(traefik_utils.traefik_prefix + "/api/entrypoint", "http")
+        self.client.put(traefik_utils.traefik_prefix + "/loglevel", "ERROR")
+        self.client.put(
+            traefik_utils.traefik_prefix + "/etcd/endpoint", "127.0.0.1:2379"
+        )
+        self.client.put(
+            traefik_utils.traefik_prefix + "/etcd/prefix", traefik_utils.traefik_prefix
+        )
+        self.client.put(traefik_utils.traefik_prefix + "/etcd/useapiv3", "true")
+        self.client.put(traefik_utils.traefik_prefix + "/etcd/watch", "true")
+
+    def _start_traefik(self):
+        self.log.info("Starting %s proxy...", self.command)
+        try:
+            self.traefik_process = traefik_utils.launch_traefik_with_etcd()
+        except FileNotFoundError as e:
+            self.log.error(
+                "Failed to find proxy %s\n"
+                "The proxy can be downloaded from https://github.com/containous/traefik/releases/download."
+                % self.command
+            )
+            raise
+
+    def _stop_traefik(self):
+        self.log.info("Cleaning up proxy[%i]...", self.traefik_process.pid)
+        self.traefik_process.kill()
+
+    def _restart_traefik(self):
+        self._stop_traefik()
+        self._start_traefik()
+
+    async def start(self):
+        """Start the proxy.
+
+        Will be called during startup if should_start is True.
+
+        **Subclasses must define this method**
+        if the proxy is to be started by the Hub
+        """
+        # TODO: investigate deploying a traefik cluster instead of a single instance!
+        self._start_traefik()
+        self._setup_etcd()
+
+    async def stop(self):
+        """Stop the proxy.
+
+        Will be called during teardown if should_start is True.
+
+        **Subclasses must define this method**
+        if the proxy is to be started by the Hub
+        """
+        self._stop_traefik()
+
+    async def add_route(self, routespec, target, data):
+        """Add a route to the proxy.
+
+        **Subclasses must define this method**
+
+        Args:
+            routespec (str): A URL prefix ([host]/path/) for which this route will be matched,
+                e.g. host.name/path/
+            target (str): A full URL that will be the target of this route.
+            data (dict): A JSONable dict that will be associated with this route, and will
+                be returned when retrieving information about this route.
+
+        Will raise an appropriate Exception (FIXME: find what?) if the route could
+        not be added.
+
+        The proxy implementation should also have a way to associate the fact that a
+        route came from JupyterHub.
+        """
+
+        self.log.info("Adding route for %s to %s.", routespec, target)
+
+        backend_alias = traefik_utils.create_backend_alias_from_url(target)
+        backend_url_path = traefik_utils.create_backend_url_path(backend_alias)
+        backend_weight_path = traefik_utils.create_backend_weight_path(backend_alias)
+        frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+        frontend_backend_path = traefik_utils.create_frontend_backend_path(
+            frontend_alias
+        )
+        frontend_rule_path = traefik_utils.create_frontend_rule_path(frontend_alias)
+
+        # To be able to delete the route when routespec is provided
+        jupyterhub_routespec = traefik_utils.jupyterhub_prefix + routespec
+        self.client.put(jupyterhub_routespec, target)
+
+        # Store the data dict passed in by JupyterHub
+        encoded_data = data = json.dumps(data)
+        self.client.put(target, encoded_data)
+
+        self.log.info("Adding backend %s with the alias.", target, backend_alias)
+        self.client.put(backend_url_path, target)
+        self.client.put(backend_weight_path, "1")
+
+        self.log.info(
+            "Adding frontend %s for backend %s with the following routing rule %s.",
+            frontend_alias,
+            backend_alias,
+            routespec,
+        )
+
+        self.client.put(frontend_backend_path, backend_alias)
+        if routespec.startswith("/"):
+            # Path-based route, e.g. /proxy/path/
+            rule = "PathPrefix:" + routespec
+        else:
+            # Host-based routing, e.g. host.tld/proxy/path/
+            host, path_prefix = routespec.split("/", 1)
+            path_prefix = "/" + path_prefix
+            rule = "Host:" + host + ";PathPrefix:" + path_prefix
+
+        self.client.put(frontend_rule_path, rule)
+
+    async def delete_route(self, routespec):
+        """Delete a route with a given routespec if it exists.
+
+        **Subclasses must define this method**
+        """
+        jupyterhub_routespec = traefik_utils.jupyterhub_prefix + routespec
+        value, _ = self.client.get(jupyterhub_routespec)
+        if value is None:
+            self.log.warning("Route %s doesn't exist. Nothing to delete", routespec)
+            return
+
+        target = value.decode()
+        if self.client.delete(jupyterhub_routespec) is False:
+            self.log.error("Couldn't delete %s.", routespec)
+        if self.client.delete(target) is False:
+            self.log.error("Couldn't delete %s.", routespec)
+
+        backend_alias = traefik_utils.create_backend_alias_from_url(target)
+        frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+
+        self.log.info(
+            'Deleting %s and %s associated with the the routespec "%s".',
+            frontend_alias,
+            backend_alias,
+            routespec,
+        )
+        self.client.delete_prefix(
+            traefik_utils.traefik_prefix + "/backends/" + backend_alias
+        )
+        self.client.delete_prefix(
+            traefik_utils.traefik_prefix + "/frontends/" + frontend_alias
+        )
+
+    async def get_all_routes(self):
+        """Fetch and return all the routes associated by JupyterHub from the
+        proxy.
+
+        **Subclasses must define this method**
+
+        Should return a dictionary of routes, where the keys are
+        routespecs and each value is a dict of the form::
+
+          {
+            'routespec': the route specification ([host]/path/)
+            'target': the target host URL (proto://host) for this route
+            'data': the attached data dict for this route (as specified in add_route)
+          }
+        """
+        all_routes = {}
+        routes = self.client.get_prefix(traefik_utils.jupyterhub_prefix)
+
+        for value, metadata in routes:
+            # Strip the "/jupyterhub" prefix from the routespec
+            routespec = metadata.key.decode().replace(
+                traefik_utils.jupyterhub_prefix, ""
+            )
+            target = value.decode()
+
+            value, _ = self.client.get(target)
+            if value is None:
+                data = None
+            else:
+                data = value.decode()
+
+            all_routes[routespec] = {
+                "routespec": routespec,
+                "target": target,
+                "data": data,
+            }
+
+        return all_routes
+
+    async def get_route(self, routespec):
+        """Return the route info for a given routespec.
+
+        Args:
+            routespec (str):
+                A URI that was used to add this route,
+                e.g. `host.tld/path/`
+
+        Returns:
+            result (dict):
+                dict with the following keys::
+
+                'routespec': The normalized route specification passed in to add_route
+                    ([host]/path/)
+                'target': The target host for this route (proto://host)
+                'data': The arbitrary data dict that was passed in by JupyterHub when adding this
+                        route.
+
+            None: if there are no routes matching the given routespec
+        """
+        jupyterhub_routespec = traefik_utils.jupyterhub_prefix + routespec
+        value, _ = self.client.get(jupyterhub_routespec)
+        if value == None:
+            return None
+        target = value.decode()
+        value, _ = self.client.get(target)
+        if value is None:
+            data = None
+        else:
+            data = value.decode()
+
+        result = {"routespec": routespec, "target": target, "data": data}
+        return result

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -74,6 +74,7 @@ class TraefikEtcdProxy(Proxy):
         )
         self.client.put(self.etcd_traefik_prefix + "etcd/useapiv3", "true")
         self.client.put(self.etcd_traefik_prefix + "etcd/watch", "true")
+        self.client.put(self.etcd_traefik_prefix + "providersThrottleDuration", "1")
 
     def _start_traefik(self):
         self.log.info("Starting %s proxy...", self.command)
@@ -91,9 +92,6 @@ class TraefikEtcdProxy(Proxy):
         self.log.info("Cleaning up proxy[%i]...", self.traefik_process.pid)
         self.traefik_process.kill()
 
-    def _restart_traefik(self):
-        self._stop_traefik()
-        self._start_traefik()
 
     async def start(self):
         """Start the proxy.

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -92,7 +92,6 @@ class TraefikEtcdProxy(Proxy):
         self.log.info("Cleaning up proxy[%i]...", self.traefik_process.pid)
         self.traefik_process.kill()
 
-
     async def start(self):
         """Start the proxy.
 

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -18,18 +18,7 @@ Route Specification:
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
-import json
-import etcd3
-import os
-
-from subprocess import Popen
-
-from traitlets import Any, Unicode
-
 from jupyterhub.proxy import Proxy
-
-from . import traefik_utils
 
 
 class TraefikProxy(Proxy):

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -27,6 +27,7 @@ from subprocess import Popen
 
 from jupyterhub.proxy import Proxy
 
+
 class TraefikProxy(Proxy):
     """JupyterHub Proxy implementation using traefik"""
 
@@ -38,16 +39,16 @@ class TraefikProxy(Proxy):
 
     def _setup_etcd(self):
         print("Seting up etcd...")
-        self.client.put(self.prefix + '/debug', 'true')
-        self.client.put(self.prefix + '/defaultentrypoints/0', 'http')
-        self.client.put(self.prefix + '/entrypoints/http/address', ':8000')
-        self.client.put(self.prefix + '/api/dashboard', 'true')
-        self.client.put(self.prefix + '/api/entrypoint', 'http')
-        self.client.put(self.prefix + '/loglevel', 'ERROR')
-        self.client.put(self.prefix + '/etcd/endpoint', '127.0.0.1:2379')
-        self.client.put(self.prefix + '/etcd/prefix', self.prefix)
-        self.client.put(self.prefix + '/etcd/useapiv3', 'true')
-        self.client.put(self.prefix + '/etcd/watch', 'true')
+        self.client.put(self.prefix + "/debug", "true")
+        self.client.put(self.prefix + "/defaultentrypoints/0", "http")
+        self.client.put(self.prefix + "/entrypoints/http/address", ":8000")
+        self.client.put(self.prefix + "/api/dashboard", "true")
+        self.client.put(self.prefix + "/api/entrypoint", "http")
+        self.client.put(self.prefix + "/loglevel", "ERROR")
+        self.client.put(self.prefix + "/etcd/endpoint", "127.0.0.1:2379")
+        self.client.put(self.prefix + "/etcd/prefix", self.prefix)
+        self.client.put(self.prefix + "/etcd/useapiv3", "true")
+        self.client.put(self.prefix + "/etcd/watch", "true")
 
     def _create_backend_alias_from_url(self, url):
         target = urlparse(url)
@@ -58,16 +59,16 @@ class TraefikProxy(Proxy):
         return "jupyterhub_frontend_" + target.netloc
 
     def _create_backend_url_path(self, backend_alias):
-        return self.prefix + '/backends/' + backend_alias + "/servers/server1/url"
+        return self.prefix + "/backends/" + backend_alias + "/servers/server1/url"
 
     def _create_backend_weight_path(self, backend_alias):
-        return self.prefix + '/backends/' + backend_alias + "/servers/server1/weight"
+        return self.prefix + "/backends/" + backend_alias + "/servers/server1/weight"
 
     def _create_frontend_backend_path(self, frontend_alias):
-        return self.prefix + '/frontends/' + frontend_alias + "/backend"
+        return self.prefix + "/frontends/" + frontend_alias + "/backend"
 
     def _create_frontend_rule_path(self, frontend_alias):
-        return self.prefix + '/frontends/' + frontend_alias + "/routes/test/rule"
+        return self.prefix + "/frontends/" + frontend_alias + "/routes/test/rule"
 
     async def start(self):
         """Start the proxy.
@@ -78,7 +79,7 @@ class TraefikProxy(Proxy):
         if the proxy is to be started by the Hub
         """
 
-        #TODO check if there is another proxy process running
+        # TODO check if there is another proxy process running
         self.traefik = Popen(["traefik", "--etcd", "--etcd.useapiv3=true"], stdout=None)
         # raise NotImplementedError()
 
@@ -94,7 +95,6 @@ class TraefikProxy(Proxy):
 
         print(self.traefik.kill())
         print(self.traefik.wait())
-
 
     async def add_route(self, routespec, target, data):
         """Add a route to the proxy.
@@ -124,14 +124,13 @@ class TraefikProxy(Proxy):
 
         self.client.put(self.jupyterhub_prefix + routespec, target)
         # To be able to delete the route when routespec is provided
-        encoded_data = data=json.dumps(data)
+        encoded_data = data = json.dumps(data)
         self.client.put(target, encoded_data)
         # Store the data dict passed in by JupyterHub
         self.client.put(backend_url_path, target)
         self.client.put(backend_weight_path, "1")
         self.client.put(frontend_backend_path, backend_alias)
         self.client.put(frontend_rule_path, "PathPrefix:" + routespec)
-
 
     async def delete_route(self, routespec):
         """Delete a route with a given routespec if it exists.
@@ -147,8 +146,8 @@ class TraefikProxy(Proxy):
         backend_alias = self._create_backend_alias_from_url(target)
         frontend_alias = self._create_frontend_alias_from_url(target)
 
-        self.client.delete_prefix(self.prefix + '/backends/' + backend_alias)
-        self.client.delete_prefix(self.prefix + '/frontends/' + frontend_alias)
+        self.client.delete_prefix(self.prefix + "/backends/" + backend_alias)
+        self.client.delete_prefix(self.prefix + "/frontends/" + frontend_alias)
 
     async def get_all_routes(self):
         """Fetch and return all the routes associated by JupyterHub from the
@@ -173,11 +172,7 @@ class TraefikProxy(Proxy):
 
             value, _ = self.client.get(target)
             data = value.decode()
-            partial_res = {
-                "routespec": routespec,
-                "target": target,
-                "data": data
-            }
+            partial_res = {"routespec": routespec, "target": target, "data": data}
 
             result[routespec] = partial_res
         return result
@@ -207,10 +202,6 @@ class TraefikProxy(Proxy):
         target = value.decode()
         value, _ = self.client.get(target)
         data = value.decode()
-        result = {
-            "routespec": routespec,
-            "target": target,
-            "data": data
-        }
+        result = {"routespec": routespec, "target": target, "data": data}
 
         return result

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -23,69 +23,17 @@ import json
 import etcd3
 import os
 
-from urllib.parse import urlparse
 from subprocess import Popen
 
 from traitlets import Any, Unicode
 
 from jupyterhub.proxy import Proxy
 
+from . import traefik_utils
+
 
 class TraefikProxy(Proxy):
     """JupyterHub Proxy implementation using traefik"""
-
-    traefik = Any()
-    client = etcd3.client("127.0.0.1", 2379)
-
-    traefik_port = 8000
-    traefik_prefix = "/traefik"
-    jupyterhub_prefix = "/jupyterhub"
-    command = "traefik"
-
-    def _setup_etcd(self):
-        self.log.info("Seting up etcd...")
-        self.client.put(self.traefik_prefix + "/debug", "true")
-        self.client.put(self.traefik_prefix + "/defaultentrypoints/0", "http")
-        self.client.put(
-            self.traefik_prefix + "/entrypoints/http/address",
-            ":" + str(self.traefik_port),
-        )
-        self.client.put(self.traefik_prefix + "/api/dashboard", "true")
-        self.client.put(self.traefik_prefix + "/api/entrypoint", "http")
-        self.client.put(self.traefik_prefix + "/loglevel", "ERROR")
-        self.client.put(self.traefik_prefix + "/etcd/endpoint", "127.0.0.1:2379")
-        self.client.put(self.traefik_prefix + "/etcd/prefix", self.traefik_prefix)
-        self.client.put(self.traefik_prefix + "/etcd/useapiv3", "true")
-        self.client.put(self.traefik_prefix + "/etcd/watch", "true")
-
-    def _create_backend_alias_from_url(self, url):
-        target = urlparse(url)
-        return "jupyterhub_backend_" + target.netloc
-
-    def _create_frontend_alias_from_url(self, url):
-        target = urlparse(url)
-        return "jupyterhub_frontend_" + target.netloc
-
-    def _create_backend_url_path(self, backend_alias):
-        return (
-            self.traefik_prefix + "/backends/" + backend_alias + "/servers/server1/url"
-        )
-
-    def _create_backend_weight_path(self, backend_alias):
-        return (
-            self.traefik_prefix
-            + "/backends/"
-            + backend_alias
-            + "/servers/server1/weight"
-        )
-
-    def _create_frontend_backend_path(self, frontend_alias):
-        return self.traefik_prefix + "/frontends/" + frontend_alias + "/backend"
-
-    def _create_frontend_rule_path(self, frontend_alias):
-        return (
-            self.traefik_prefix + "/frontends/" + frontend_alias + "/routes/test/rule"
-        )
 
     async def start(self):
         """Start the proxy.
@@ -95,20 +43,7 @@ class TraefikProxy(Proxy):
         **Subclasses must define this method**
         if the proxy is to be started by the Hub
         """
-        # TODO: investigate deploying a traefik cluster instead of a single instance!
-        self.log.info("Starting %s proxy...", self.command)
-        self._setup_etcd()
-        try:
-            self.traefik = Popen(
-                [self.command, "--etcd", "--etcd.useapiv3=true"], stdout=None
-            )
-        except FileNotFoundError as e:
-            self.log.error(
-                "Failed to find proxy %s\n"
-                "The proxy can be downloaded from https://github.com/containous/traefik/releases/download."
-                % self.command
-            )
-            raise
+        raise NotImplementedError()
 
     async def stop(self):
         """Stop the proxy.
@@ -118,8 +53,7 @@ class TraefikProxy(Proxy):
         **Subclasses must define this method**
         if the proxy is to be started by the Hub
         """
-        self.log.info("Cleaning up proxy[%i]...", self.traefik.pid)
-        self.traefik.kill()
+        raise NotImplementedError()
 
     async def add_route(self, routespec, target, data):
         """Add a route to the proxy.
@@ -139,76 +73,14 @@ class TraefikProxy(Proxy):
         The proxy implementation should also have a way to associate the fact that a
         route came from JupyterHub.
         """
-
-        self.log.info("Adding route for %s to %s.", routespec, target)
-
-        backend_alias = self._create_backend_alias_from_url(target)
-        backend_url_path = self._create_backend_url_path(backend_alias)
-        backend_weight_path = self._create_backend_weight_path(backend_alias)
-        frontend_alias = self._create_frontend_alias_from_url(target)
-        frontend_backend_path = self._create_frontend_backend_path(frontend_alias)
-        frontend_rule_path = self._create_frontend_rule_path(frontend_alias)
-
-        # To be able to delete the route when routespec is provided
-        if routespec.startswith("/"):
-            self.client.put(self.jupyterhub_prefix + routespec, target)
-        else:
-            self.client.put(self.jupyterhub_prefix + "/" + routespec, target)
-        # Store the data dict passed in by JupyterHub
-        encoded_data = data = json.dumps(data)
-        self.client.put(target, encoded_data)
-
-        self.log.info("Adding backend %s with the alias.", target, backend_alias)
-        self.client.put(backend_url_path, target)
-        self.client.put(backend_weight_path, "1")
-
-        self.log.info(
-            "Adding frontend %s for backend %s with the following routing rule %s.",
-            frontend_alias,
-            backend_alias,
-            routespec,
-        )
-        self.client.put(frontend_backend_path, backend_alias)
-        if routespec.startswith("/"):
-            # Path-based route, e.g. /proxy/path/
-            rule = "PathPrefix:" + routespec
-        else:
-            # Host-based routing, e.g. host.tld/proxy/path/
-            host, path_prefix = routespec.split("/", 1)
-            path_prefix = "/" + path_prefix
-            rule = "Host:" + host + ";PathPrefix:" + path_prefix
-
-        self.client.put(frontend_rule_path, rule)
+        raise NotImplementedError()
 
     async def delete_route(self, routespec):
         """Delete a route with a given routespec if it exists.
 
         **Subclasses must define this method**
         """
-        value, _ = self.client.get(self.jupyterhub_prefix + routespec)
-        if value is None:
-            self.log.warning("Route %s doesn't exist. Nothing to delete", routespec)
-            return
-
-        target = value.decode()
-        rc = self.client.delete(self.jupyterhub_prefix + routespec)
-        if rc is False:
-            self.log.error("Couldn't delete %s.", routespec)
-        rc = self.client.delete(target)
-        if rc is False:
-            self.log.error("Couldn't delete %s.", routespec)
-
-        backend_alias = self._create_backend_alias_from_url(target)
-        frontend_alias = self._create_frontend_alias_from_url(target)
-
-        self.log.info(
-            'Deleting %s and %s associated with the the routespec "%s".',
-            frontend_alias,
-            backend_alias,
-            routespec,
-        )
-        self.client.delete_prefix(self.traefik_prefix + "/backends/" + backend_alias)
-        self.client.delete_prefix(self.traefik_prefix + "/frontends/" + frontend_alias)
+        raise NotImplementedError()
 
     async def get_all_routes(self):
         """Fetch and return all the routes associated by JupyterHub from the
@@ -225,27 +97,7 @@ class TraefikProxy(Proxy):
             'data': the attached data dict for this route (as specified in add_route)
           }
         """
-        all_routes = {}
-        routes = self.client.get_prefix(self.jupyterhub_prefix)
-
-        for value, metadata in routes:
-            # Strip the "/jupyterhub" prefix from the routespec
-            routespec = metadata.key.decode().replace(self.jupyterhub_prefix, "")
-            target = value.decode()
-
-            value, _ = self.client.get(target)
-            if value is None:
-                data = None
-            else:
-                data = value.decode()
-
-            all_routes[routespec] = {
-                "routespec": routespec,
-                "target": target,
-                "data": data,
-            }
-
-        return all_routes
+        raise NotImplementedError()
 
     async def get_route(self, routespec):
         """Return the route info for a given routespec.
@@ -267,16 +119,4 @@ class TraefikProxy(Proxy):
 
             None: if there are no routes matching the given routespec
         """
-
-        value, _ = self.client.get(self.jupyterhub_prefix + routespec)
-        if value == None:
-            return None
-        target = value.decode()
-        value, _ = self.client.get(target)
-        if value is None:
-            data = None
-        else:
-            data = value.decode()
-
-        result = {"routespec": routespec, "target": target, "data": data}
-        return result
+        raise NotImplementedError()

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -73,6 +73,7 @@ def check_traefik_etcd_static_conf_ready():
             time.sleep(t)
     assert ready  # Check that we got here because we are ready
 
+
 def check_traefik_etcd_dynamic_conf_ready(expected_no_of_entries):
     base_url = "http://localhost:" + str(get_port("traefik"))
     """ Allow traefik up to 10 sec to load its dynamic configuration from the
@@ -89,11 +90,15 @@ def check_traefik_etcd_dynamic_conf_ready(expected_no_of_entries):
             no_of_backend_entries = len(resp_backends.json())
         if resp_frontends.status_code == 200:
             no_of_frontend_entries = len(resp_frontends.json())
-        ready = no_of_backend_entries == expected_no_of_entries and no_of_frontend_entries == expected_no_of_entries
+        ready = (
+            no_of_backend_entries == expected_no_of_entries
+            and no_of_frontend_entries == expected_no_of_entries
+        )
         if not ready:
             t = min(2, t * 2)
             time.sleep(t)
     assert ready  # Check that we got here because we are ready
+
 
 def get_backend_ports():
     default_backend_port = get_port("default_backend")

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -1,0 +1,170 @@
+import time
+import socket
+import sys
+import requests
+import etcd3
+from os.path import abspath, dirname, join
+from subprocess import Popen
+from urllib.parse import urlparse
+
+
+_ports = {
+    "traefik": 8000,
+    "default_backend": 9000,
+    "first_backend": 9090,
+    "second_backend": 9099,
+}
+
+traefik_prefix = "/traefik"
+jupyterhub_prefix = "/jupyterhub/"
+
+
+def get_port(service_name):
+    return _ports[service_name]
+
+
+def is_open(ip, port):
+    timeout = 1
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+    try:
+        s.connect((ip, port))
+        s.shutdown(socket.SHUT_RDWR)
+        return True
+    except:
+        return False
+    finally:
+        s.close()
+
+
+def check_host_up(ip, port):
+    """ Allow the service up to 2 sec to open connection on the
+    designated port """
+    up = False
+    retry = 20  # iterations
+    delay = 0.1  # 100 ms
+
+    for i in range(retry):
+        if is_open(ip, port):
+            up = True
+            break
+        else:
+            time.sleep(delay)
+    return up
+
+
+def traefik_routes_to_correct_backend(path, expected_port):
+    """ Check if traefik followed the configuration and routed the
+    request to the right backend """
+    base_url = "http://localhost:" + str(get_port("traefik"))
+    resp = requests.get(base_url + path)
+    assert int(resp.text) == expected_port
+
+
+def check_traefik_etcd_conf_ready():
+    base_url = "http://localhost:" + str(get_port("traefik"))
+    """ Allow traefik up to 10 sec to load its configuration from the
+    etcd cluster """
+    timeout = time.time() + 10
+    ready = False
+    t = 0.1
+    while not ready and time.time() < timeout:
+        resp = requests.get(base_url + "/api/providers/etcdv3")
+        ready = resp.status_code == 200
+        if not ready:
+            t = min(2, t * 2)
+            time.sleep(t)
+    assert ready  # Check that we got here because we are ready
+
+
+def get_backend_ports():
+    default_backend_port = get_port("default_backend")
+    first_backend_port = get_port("first_backend")
+    second_backend_port = get_port("second_backend")
+    return default_backend_port, first_backend_port, second_backend_port
+
+
+def check_backends_up():
+    """ Verify if the backends started listening on their designated
+    ports """
+    default_backend_port, first_backend_port, second_backend_port = get_backend_ports()
+    assert check_host_up("localhost", default_backend_port) == True
+    assert check_host_up("localhost", first_backend_port) == True
+    assert check_host_up("localhost", second_backend_port) == True
+
+
+def check_traefik_up():
+    """ Verify if traefik started listening on its designated port """
+    traefik_port = get_port("traefik")
+    assert check_host_up("localhost", traefik_port) == True
+
+
+def launch_backends():
+    default_backend_port, first_backend_port, second_backend_port = get_backend_ports()
+    dummy_server_path = abspath(join(dirname(__file__), "dummy_http_server.py"))
+
+    default_backend = Popen(
+        [sys.executable, dummy_server_path, str(default_backend_port)], stdout=None
+    )
+    first_backend = Popen(
+        [sys.executable, dummy_server_path, str(first_backend_port)], stdout=None
+    )
+    second_backend = Popen(
+        [sys.executable, dummy_server_path, str(second_backend_port)], stdout=None
+    )
+    return default_backend, first_backend, second_backend
+
+
+def launch_traefik_with_toml():
+    traefik_port = get_port("traefik")
+    config_file_path = abspath(join(dirname(__file__), "traefik.toml"))
+    traefik = Popen(["traefik", "-c", config_file_path], stdout=None)
+    return traefik
+
+
+def launch_traefik_with_etcd():
+    traefik_port = get_port("traefik")
+    traefik = Popen(["traefik", "--etcd", "--etcd.useapiv3=true"], stdout=None)
+    return traefik
+
+
+def check_routing():
+    default_backend_port, first_backend_port, second_backend_port = get_backend_ports()
+    """ Send GET requests for resources on different paths and check
+    they are routed based on their path-prefixes """
+    traefik_routes_to_correct_backend("/otherthings", default_backend_port)
+    traefik_routes_to_correct_backend("/user/somebody", default_backend_port)
+    traefik_routes_to_correct_backend("/user/first", first_backend_port)
+    traefik_routes_to_correct_backend("/user/second", second_backend_port)
+    traefik_routes_to_correct_backend("/user/first/otherthings", first_backend_port)
+    traefik_routes_to_correct_backend("/user/second/otherthings", second_backend_port)
+
+
+def generate_traefik_toml():
+    pass  # Not implemented
+
+
+def create_backend_alias_from_url(url):
+    target = urlparse(url)
+    return "jupyterhub_backend_" + target.netloc
+
+
+def create_frontend_alias_from_url(url):
+    target = urlparse(url)
+    return "jupyterhub_frontend_" + target.netloc
+
+
+def create_backend_url_path(backend_alias):
+    return traefik_prefix + "/backends/" + backend_alias + "/servers/server1/url"
+
+
+def create_backend_weight_path(backend_alias):
+    return traefik_prefix + "/backends/" + backend_alias + "/servers/server1/weight"
+
+
+def create_frontend_backend_path(frontend_alias):
+    return traefik_prefix + "/frontends/" + frontend_alias + "/backend"
+
+
+def create_frontend_rule_path(frontend_alias):
+    return traefik_prefix + "/frontends/" + frontend_alias + "/routes/test/rule"

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -15,9 +15,6 @@ _ports = {
     "second_backend": 9099,
 }
 
-traefik_prefix = "/traefik"
-jupyterhub_prefix = "/jupyterhub/"
-
 
 def get_port(service_name):
     return _ports[service_name]
@@ -154,17 +151,26 @@ def create_frontend_alias_from_url(url):
     return "jupyterhub_frontend_" + target.netloc
 
 
-def create_backend_url_path(backend_alias):
-    return traefik_prefix + "/backends/" + backend_alias + "/servers/server1/url"
+def create_backend_url_path(proxy, backend_alias):
+    return (
+        proxy.etcd_traefik_prefix + "backends/" + backend_alias + "/servers/server1/url"
+    )
 
 
-def create_backend_weight_path(backend_alias):
-    return traefik_prefix + "/backends/" + backend_alias + "/servers/server1/weight"
+def create_backend_weight_path(proxy, backend_alias):
+    return (
+        proxy.etcd_traefik_prefix
+        + "backends/"
+        + backend_alias
+        + "/servers/server1/weight"
+    )
 
 
-def create_frontend_backend_path(frontend_alias):
-    return traefik_prefix + "/frontends/" + frontend_alias + "/backend"
+def create_frontend_backend_path(proxy, frontend_alias):
+    return proxy.etcd_traefik_prefix + "frontends/" + frontend_alias + "/backend"
 
 
-def create_frontend_rule_path(frontend_alias):
-    return traefik_prefix + "/frontends/" + frontend_alias + "/routes/test/rule"
+def create_frontend_rule_path(proxy, frontend_alias):
+    return (
+        proxy.etcd_traefik_prefix + "frontends/" + frontend_alias + "/routes/test/rule"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,10 @@ from jupyterhub_traefik_proxy import TraefikProxy
 
 
 @pytest.fixture
-def proxy():
+async def proxy():
     """Fixture returning a configured Traefik Proxy"""
     # TODO: set up the proxy
     proxy = TraefikProxy()
+    proxy._setup_etcd()
+    await proxy.start()
     yield proxy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ async def proxy():
     await proxy.start()
     yield proxy
 
+
 @pytest.fixture
 def restart_traefik_proc(proxy):
     proxy._stop_traefik()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from jupyterhub_traefik_proxy import TraefikEtcdProxy
 @pytest.fixture
 async def proxy():
     """Fixture returning a configured Traefik Proxy"""
-    # TODO: set up the proxy
     proxy = TraefikEtcdProxy()
     await proxy.start()
     yield proxy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,5 @@ async def proxy():
     """Fixture returning a configured Traefik Proxy"""
     # TODO: set up the proxy
     proxy = TraefikProxy()
-    proxy._setup_etcd()
     await proxy.start()
     yield proxy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-from jupyterhub_traefik_proxy import TraefikProxy
+from jupyterhub_traefik_proxy import TraefikEtcdProxy
 
 
 @pytest.fixture
 async def proxy():
     """Fixture returning a configured Traefik Proxy"""
     # TODO: set up the proxy
-    proxy = TraefikProxy()
+    proxy = TraefikEtcdProxy()
     await proxy.start()
     yield proxy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,8 @@ async def proxy():
     proxy = TraefikEtcdProxy()
     await proxy.start()
     yield proxy
+
+@pytest.fixture
+def restart_traefik_proc(proxy):
+    proxy._stop_traefik()
+    proxy._start_traefik()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,29 +1,38 @@
 """Tests for the base traefik proxy"""
 
 import pytest
+import json
 
 # mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
 
 async def test_add_route(proxy):
-    with pytest.raises(NotImplementedError):
-        route = await proxy.add_route("/prefix", "http://127.0.0.1:9999", {})
+    # with pytest.raises(NotImplementedError):
+    await proxy.add_route("/prefix", "http://127.0.0.1:99", {"test": "test0"})
+    await proxy.add_route("/prefix0", "http://127.0.0.1:1000", {"test": "test0"})
+    await proxy.stop()
+    # print("route is " + route)
     # TODO: test the route
 
 
 async def test_get_all_routes(proxy):
-    with pytest.raises(NotImplementedError):
-        routes = await proxy.get_all_routes()
+    # with pytest.raises(NotImplementedError):
+    routes = await proxy.get_all_routes()
+    print(json.dumps(routes, sort_keys=True, indent=4, separators=(',', ': ')))
+    await proxy.stop()
     # TODO: test the routes
 
 
 async def test_delete_route(proxy):
-    with pytest.raises(NotImplementedError):
-        await proxy.delete_route("/prefix")
+    # with pytest.raises(NotImplementedError):
+    await proxy.delete_route("/prefix0")
+    await proxy.stop()
 
 
 async def test_get_route(proxy):
-    with pytest.raises(NotImplementedError):
-        route = await proxy.get_route("/prefix")
+    # with pytest.raises(NotImplementedError):
+    route = await proxy.get_route("/prefix")
+    print(json.dumps(route, sort_keys=True, indent=4, separators=(',', ': ')))
+    await proxy.stop()
     # TODO: test the route

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -19,7 +19,7 @@ async def test_add_route(proxy):
 async def test_get_all_routes(proxy):
     # with pytest.raises(NotImplementedError):
     routes = await proxy.get_all_routes()
-    print(json.dumps(routes, sort_keys=True, indent=4, separators=(',', ': ')))
+    print(json.dumps(routes, sort_keys=True, indent=4, separators=(",", ": ")))
     await proxy.stop()
     # TODO: test the routes
 
@@ -33,6 +33,6 @@ async def test_delete_route(proxy):
 async def test_get_route(proxy):
     # with pytest.raises(NotImplementedError):
     route = await proxy.get_route("/prefix")
-    print(json.dumps(route, sort_keys=True, indent=4, separators=(',', ': ')))
+    print(json.dumps(route, sort_keys=True, indent=4, separators=(",", ": ")))
     await proxy.stop()
     # TODO: test the route

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -5,18 +5,17 @@ import json
 from os.path import abspath, dirname, join, pardir
 import subprocess
 import sys
+from jupyterhub_traefik_proxy import traefik_utils
+import asyncio
 
 # mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
 etcdctl_path = abspath(
-    join(dirname(__file__), pardir, "etcd-v3.3.9-linux-amd64/etcdctl")
+    join(dirname(__file__), pardir, "etcd-v3.3.10-linux-amd64/etcdctl")
 )
 
-jupyterhub_prefix = "/jupyterhub"
 default_backend_weight = "1"
-
-# TODO: remove proxy from the args and move functions to utils file
 
 
 def assert_etcdctl_get(key, expected_rv):
@@ -37,26 +36,41 @@ def assert_etcdctl_put(key, value, expected_rv):
     )
 
 
-def add_route_with_etcdctl(proxy, routespec, target, data):
-    expected_rv = "OK"
-    jupyterhub_routespec = jupyterhub_prefix + routespec
+def assert_etcdctl_del(key, expected_rv):
+    assert (
+        subprocess.check_output([etcdctl_path, "del", key])
+        .decode(sys.stdout.encoding)
+        .strip()
+        == expected_rv
+    )
 
-    assert_etcdctl_put(jupyterhub_routespec, target, expected_rv)
-    assert_etcdctl_put(target, json.dumps(data), expected_rv)
 
-    backend_alias = proxy._create_backend_alias_from_url(target)
-    backend_url_path = proxy._create_backend_url_path(backend_alias)
-    assert_etcdctl_put(backend_url_path, target, expected_rv)
+def cleanup_test_route(routespec, target, data):
+    jupyterhub_routespec = traefik_utils.jupyterhub_prefix + routespec
+    backend_alias = traefik_utils.create_backend_alias_from_url(target)
+    backend_url_path = traefik_utils.create_backend_url_path(backend_alias)
+    backend_weight_path = traefik_utils.create_backend_weight_path(backend_alias)
+    frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+    frontend_backend_path = traefik_utils.create_frontend_backend_path(frontend_alias)
+    frontend_rule_path = traefik_utils.create_frontend_rule_path(frontend_alias)
+    expected_rv = "1"  # Number of deleted entries
 
-    backend_weight_path = proxy._create_backend_weight_path(backend_alias)
-    assert_etcdctl_put(backend_weight_path, default_backend_weight, expected_rv)
+    assert_etcdctl_del(jupyterhub_routespec, expected_rv)
+    assert_etcdctl_del(target, expected_rv)
+    assert_etcdctl_del(backend_url_path, expected_rv)
+    assert_etcdctl_del(backend_weight_path, expected_rv)
+    assert_etcdctl_del(frontend_backend_path, expected_rv)
+    assert_etcdctl_del(frontend_rule_path, expected_rv)
 
-    frontend_alias = proxy._create_frontend_alias_from_url(target)
-    frontend_backend_path = proxy._create_frontend_backend_path(frontend_alias)
-    assert_etcdctl_put(frontend_backend_path, backend_alias, expected_rv)
 
-    # Test that a path-routing rule has been added for this frontend
-    frontend_rule_path = proxy._create_frontend_rule_path(frontend_alias)
+def add_route_with_etcdctl(routespec, target, data):
+    jupyterhub_routespec = traefik_utils.jupyterhub_prefix + routespec
+    backend_alias = traefik_utils.create_backend_alias_from_url(target)
+    backend_url_path = traefik_utils.create_backend_url_path(backend_alias)
+    backend_weight_path = traefik_utils.create_backend_weight_path(backend_alias)
+    frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+    frontend_backend_path = traefik_utils.create_frontend_backend_path(frontend_alias)
+    frontend_rule_path = traefik_utils.create_frontend_rule_path(frontend_alias)
     if routespec.startswith("/"):
         # Path-based route, e.g. /proxy/path/
         rule = "PathPrefix:" + routespec
@@ -65,15 +79,34 @@ def add_route_with_etcdctl(proxy, routespec, target, data):
         host, path_prefix = routespec.split("/", 1)
         path_prefix = "/" + path_prefix
         rule = "Host:" + host + ";PathPrefix:" + path_prefix
+    expected_rv = "OK"
+
+    assert_etcdctl_put(jupyterhub_routespec, target, expected_rv)
+    assert_etcdctl_put(target, json.dumps(data), expected_rv)
+    assert_etcdctl_put(backend_url_path, target, expected_rv)
+    assert_etcdctl_put(backend_weight_path, default_backend_weight, expected_rv)
+    assert_etcdctl_put(frontend_backend_path, backend_alias, expected_rv)
     assert_etcdctl_put(frontend_rule_path, rule, expected_rv)
 
 
-def check_route_with_etcdl(proxy, routespec, target, data, test_deletion=False):
-    jupyterhub_routespec = (
-        jupyterhub_prefix + routespec
-        if routespec.startswith("/")
-        else jupyterhub_prefix + "/" + routespec
-    )
+def check_route_with_etcdl(routespec, target, data, test_deletion=False):
+    jupyterhub_routespec = traefik_utils.jupyterhub_prefix + routespec
+    backend_alias = traefik_utils.create_backend_alias_from_url(target)
+    backend_url_path = traefik_utils.create_backend_url_path(backend_alias)
+    backend_alias = traefik_utils.create_backend_alias_from_url(target)
+    backend_weight_path = traefik_utils.create_backend_weight_path(backend_alias)
+    frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+    frontend_backend_path = traefik_utils.create_frontend_backend_path(frontend_alias)
+    frontend_rule_path = traefik_utils.create_frontend_rule_path(frontend_alias)
+    if routespec.startswith("/"):
+        # Path-based route, e.g. /proxy/path/
+        rule = "PathPrefix:" + routespec
+    else:
+        # Host-based routing, e.g. host.tld/proxy/path/
+        host, path_prefix = routespec.split("/", 1)
+        path_prefix = "/" + path_prefix
+        rule = "Host:" + host + ";PathPrefix:" + path_prefix
+
     if test_deletion:
         expected_rv = ""
     else:
@@ -88,105 +121,169 @@ def check_route_with_etcdl(proxy, routespec, target, data, test_deletion=False):
     assert_etcdctl_get(target, expected_rv)
 
     # Test that a backend has been added to etcd for this target
-    backend_alias = proxy._create_backend_alias_from_url(target)
-    backend_url_path = proxy._create_backend_url_path(backend_alias)
     if not test_deletion:
         expected_rv = backend_url_path + "\n" + target
     assert_etcdctl_get(backend_url_path, expected_rv)
 
     # Test that a backend weight has been added to etcd for this target
-    backend_alias = proxy._create_backend_alias_from_url(target)
-    backend_weight_path = proxy._create_backend_weight_path(backend_alias)
     if not test_deletion:
         expected_rv = backend_weight_path + "\n" + default_backend_weight
     assert_etcdctl_get(backend_weight_path, expected_rv)
 
     # Test that a frontend has been added for the prev backend
-    frontend_alias = proxy._create_frontend_alias_from_url(target)
-    frontend_backend_path = proxy._create_frontend_backend_path(frontend_alias)
     if not test_deletion:
         expected_rv = frontend_backend_path + "\n" + backend_alias
     assert_etcdctl_get(frontend_backend_path, expected_rv)
 
     # Test that a path-routing rule has been added for this frontend
-    frontend_rule_path = proxy._create_frontend_rule_path(frontend_alias)
-
-    if routespec.startswith("/"):
-        # Path-based route, e.g. /proxy/path/
-        rule = "PathPrefix:" + routespec
-    else:
-        # Host-based routing, e.g. host.tld/proxy/path/
-        host, path_prefix = routespec.split("/", 1)
-        path_prefix = "/" + path_prefix
-        rule = "Host:" + host + ";PathPrefix:" + path_prefix
-
     if not test_deletion:
         expected_rv = frontend_rule_path + "\n" + rule
     assert_etcdctl_get(frontend_rule_path, expected_rv)
 
 
-async def test_add_path_based_route_to_etcd(proxy):
-    routespec = "/proxy/path"
-    target = "http://127.0.0.1:99"
-    data = {"test": "test1"}
-
+@pytest.mark.parametrize(
+    "routespec, target, data",
+    [
+        ("/proxy/path", "http://127.0.0.1:99", {"test": "test1"}),  # Path-based routing
+        ("/proxy/path", "http://127.0.0.1:99", {}),  # Path-based routing, no data dict
+        # Host-based routing
+        ("host/proxy/path", "http://127.0.0.1:99", {"test": "test2"}),
+    ],
+)
+async def test_add_path_based_route_to_etcd(proxy, routespec, target, data):
     await proxy.add_route(routespec, target, data)
 
     try:
-        check_route_with_etcdl(proxy, routespec, target, data)
+        check_route_with_etcdl(routespec, target, data)
+        cleanup_test_route(routespec, target, data)
     finally:
         await proxy.stop()
 
 
-async def test_add_host_based_route_to_etcd(proxy):
-    routespec = "host/proxy/path"
-    target = "http://127.0.0.1:909"
-    data = {"test": "test2"}
-
-    await proxy.add_route(routespec, target, data)
+@pytest.mark.parametrize(
+    "routespec, target, data",
+    [
+        ("/proxy/path", "http://127.0.0.1:99", {"test": "test1"}),  # Path-based routing
+        ("/proxy/path", "http://127.0.0.1:99", {}),  # Path-based routing, no data dict
+        # Host-based routing
+        ("host/proxy/path", "http://127.0.0.1:99", {"test": "test2"}),
+    ],
+)
+async def test_delete_route_from_etcd(proxy, routespec, target, data):
+    add_route_with_etcdctl(routespec, target, data)
+    await proxy.delete_route(routespec)
 
     try:
         # Test that (routespec, target) pair has been added to etcd
-        check_route_with_etcdl(proxy, routespec, target, data, False)
+        check_route_with_etcdl(routespec, target, data, True)
     finally:
         await proxy.stop()
 
 
-async def test_delete_route_from_etcd(proxy):
-    routespec = "/proxy/another_path"
-    target = "http://127.0.0.1:990"
-    data = {"test": "test3"}
-
-    add_route_with_etcdctl(proxy, routespec, target, data)
-    await proxy.delete_route("/proxy/another_path")
-    try:
-        # Test that (routespec, target) pair has been added to etcd
-        check_route_with_etcdl(proxy, routespec, target, data, True)
-    finally:
-        await proxy.stop()
-
-
-async def test_get_all_routes(proxy):
-    # with pytest.raises(NotImplementedError):
-    routes = await proxy.get_all_routes()
-    print(json.dumps(routes, sort_keys=True, indent=4, separators=(",", ": ")))
-    await proxy.stop()
-    # TODO: test the routes
-
-
-async def test_get_route(proxy):
-    routespec = "/proxy/just_another_path"
-    target = "http://127.0.0.1:990"
-    data = {"test": "test4"}
-    expected_output = {
-        "routespec": routespec,
-        "target": target,
-        "data": json.dumps(data),
-    }
-
-    add_route_with_etcdctl(proxy, routespec, target, data)
+@pytest.mark.parametrize(
+    "routespec, target, data, expected_output",
+    [
+        (
+            "/proxy/path",
+            "http://127.0.0.1:99",
+            {"test": "test1"},
+            {
+                "routespec": "/proxy/path",
+                "target": "http://127.0.0.1:99",
+                "data": json.dumps({"test": "test1"}),
+            },
+        ),  # Path-based routing
+        (
+            "/proxy/path",
+            "http://127.0.0.1:99",
+            {},
+            {"routespec": "/proxy/path", "target": "http://127.0.0.1:99", "data": "{}"},
+        ),  # Path-based routing, no data dict
+        (
+            "host/proxy/path",
+            "http://127.0.0.1:99",
+            {"test": "test2"},
+            {
+                "routespec": "host/proxy/path",
+                "target": "http://127.0.0.1:99",
+                "data": json.dumps({"test": "test2"}),
+            },
+        ),  # Host-based routing
+    ],
+)
+async def test_get_route(proxy, routespec, target, data, expected_output):
+    add_route_with_etcdctl(routespec, target, data)
     route = await proxy.get_route(routespec)
+    cleanup_test_route(routespec, target, data)
 
     assert route == expected_output
     await proxy.stop()
-    # preety_formated_result = json.dumps(route, sort_keys=True, indent=4, separators=(",", ": "))
+
+
+async def test_get_all_routes(proxy):
+    routespec = ["/proxy/path1", "/proxy/path2", "host/proxy/path"]
+    target = ["http://127.0.0.1:990", "http://127.0.0.1:909", "http://127.0.0.1:999"]
+    data = [{"test": "test1"}, {}, {"test": "test2"}]
+    dict_keys = ["routespec", "target", "data"]
+
+    expected_output = {
+        routespec[0]: {
+            "routespec": routespec[0],
+            "target": target[0],
+            "data": json.dumps(data[0]),
+        },
+        routespec[1]: {
+            "routespec": routespec[1],
+            "target": target[1],
+            "data": json.dumps(data[1]),
+        },
+        routespec[2]: {
+            "routespec": routespec[2],
+            "target": target[2],
+            "data": json.dumps(data[2]),
+        },
+    }
+
+    add_route_with_etcdctl(routespec[0], target[0], data[0])
+    add_route_with_etcdctl(routespec[1], target[1], data[1])
+    add_route_with_etcdctl(routespec[2], target[2], data[2])
+    routes = await proxy.get_all_routes()
+    try:
+        assert routes == expected_output
+    finally:
+        cleanup_test_route(routespec[0], target[0], data[0])
+        cleanup_test_route(routespec[1], target[1], data[1])
+        cleanup_test_route(routespec[2], target[2], data[2])
+        await proxy.stop()
+
+
+async def test_etcd_routing(proxy):
+    routespec = ["/", "/user/first", "/user/second"]
+    target = ["http://127.0.0.1:9000", "http://127.0.0.1:9090", "http://127.0.0.1:9099"]
+    data = [{}, {}, {}]
+    try:
+        await proxy.add_route(routespec[0], target[0], data[0])
+        await proxy.add_route(routespec[1], target[1], data[1])
+        await proxy.add_route(routespec[2], target[2], data[2])
+        """ Force the proxy reload its configuration from etcd, otherwise
+            we have no other way to ensure traefik loaded the newly added routes
+            from etcd.
+        """
+        proxy._stop_traefik()
+        proxy._start_traefik()
+        traefik_utils.check_traefik_up()
+        traefik_utils.check_traefik_etcd_conf_ready()
+        default_backend, first_backend, second_backend = traefik_utils.launch_backends()
+        traefik_utils.check_backends_up()
+        traefik_utils.check_routing()
+    finally:
+        default_backend.kill()
+        first_backend.kill()
+        second_backend.kill()
+        default_backend.wait()
+        first_backend.wait()
+        second_backend.wait()
+        await proxy.stop()
+        cleanup_test_route(routespec[0], target[0], data[0])
+        cleanup_test_route(routespec[1], target[1], data[1])
+        cleanup_test_route(routespec[2], target[2], data[2])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -2,18 +2,168 @@
 
 import pytest
 import json
+from os.path import abspath, dirname, join, pardir
+import subprocess
+import sys
 
 # mark all tests in this file as asyncio
 pytestmark = pytest.mark.asyncio
 
+etcdctl_path = abspath(
+    join(dirname(__file__), pardir, "etcd-v3.3.9-linux-amd64/etcdctl")
+)
 
-async def test_add_route(proxy):
-    # with pytest.raises(NotImplementedError):
-    await proxy.add_route("/prefix", "http://127.0.0.1:99", {"test": "test0"})
-    await proxy.add_route("/prefix0", "http://127.0.0.1:1000", {"test": "test0"})
-    await proxy.stop()
-    # print("route is " + route)
-    # TODO: test the route
+jupyterhub_prefix = "/jupyterhub"
+default_backend_weight = "1"
+
+# TODO: remove proxy from the args and move functions to utils file
+
+
+def assert_etcdctl_get(key, expected_rv):
+    assert (
+        subprocess.check_output([etcdctl_path, "get", key])
+        .decode(sys.stdout.encoding)
+        .strip()
+        == expected_rv
+    )
+
+
+def assert_etcdctl_put(key, value, expected_rv):
+    assert (
+        subprocess.check_output([etcdctl_path, "put", key, value])
+        .decode(sys.stdout.encoding)
+        .strip()
+        == expected_rv
+    )
+
+
+def add_route_with_etcdctl(proxy, routespec, target, data):
+    expected_rv = "OK"
+    jupyterhub_routespec = jupyterhub_prefix + routespec
+
+    assert_etcdctl_put(jupyterhub_routespec, target, expected_rv)
+    assert_etcdctl_put(target, json.dumps(data), expected_rv)
+
+    backend_alias = proxy._create_backend_alias_from_url(target)
+    backend_url_path = proxy._create_backend_url_path(backend_alias)
+    assert_etcdctl_put(backend_url_path, target, expected_rv)
+
+    backend_weight_path = proxy._create_backend_weight_path(backend_alias)
+    assert_etcdctl_put(backend_weight_path, default_backend_weight, expected_rv)
+
+    frontend_alias = proxy._create_frontend_alias_from_url(target)
+    frontend_backend_path = proxy._create_frontend_backend_path(frontend_alias)
+    assert_etcdctl_put(frontend_backend_path, backend_alias, expected_rv)
+
+    # Test that a path-routing rule has been added for this frontend
+    frontend_rule_path = proxy._create_frontend_rule_path(frontend_alias)
+    if routespec.startswith("/"):
+        # Path-based route, e.g. /proxy/path/
+        rule = "PathPrefix:" + routespec
+    else:
+        # Host-based routing, e.g. host.tld/proxy/path/
+        host, path_prefix = routespec.split("/", 1)
+        path_prefix = "/" + path_prefix
+        rule = "Host:" + host + ";PathPrefix:" + path_prefix
+    assert_etcdctl_put(frontend_rule_path, rule, expected_rv)
+
+
+def check_route_with_etcdl(proxy, routespec, target, data, test_deletion=False):
+    jupyterhub_routespec = (
+        jupyterhub_prefix + routespec
+        if routespec.startswith("/")
+        else jupyterhub_prefix + "/" + routespec
+    )
+    if test_deletion:
+        expected_rv = ""
+    else:
+        expected_rv = jupyterhub_routespec + "\n" + target
+
+    # Test that (routespec, target) pair has been added to etcd
+    assert_etcdctl_get(jupyterhub_routespec, expected_rv)
+
+    # Test that (target, data) pair has been added to etcd
+    if not test_deletion:
+        expected_rv = target + "\n" + json.dumps(data)
+    assert_etcdctl_get(target, expected_rv)
+
+    # Test that a backend has been added to etcd for this target
+    backend_alias = proxy._create_backend_alias_from_url(target)
+    backend_url_path = proxy._create_backend_url_path(backend_alias)
+    if not test_deletion:
+        expected_rv = backend_url_path + "\n" + target
+    assert_etcdctl_get(backend_url_path, expected_rv)
+
+    # Test that a backend weight has been added to etcd for this target
+    backend_alias = proxy._create_backend_alias_from_url(target)
+    backend_weight_path = proxy._create_backend_weight_path(backend_alias)
+    if not test_deletion:
+        expected_rv = backend_weight_path + "\n" + default_backend_weight
+    assert_etcdctl_get(backend_weight_path, expected_rv)
+
+    # Test that a frontend has been added for the prev backend
+    frontend_alias = proxy._create_frontend_alias_from_url(target)
+    frontend_backend_path = proxy._create_frontend_backend_path(frontend_alias)
+    if not test_deletion:
+        expected_rv = frontend_backend_path + "\n" + backend_alias
+    assert_etcdctl_get(frontend_backend_path, expected_rv)
+
+    # Test that a path-routing rule has been added for this frontend
+    frontend_rule_path = proxy._create_frontend_rule_path(frontend_alias)
+
+    if routespec.startswith("/"):
+        # Path-based route, e.g. /proxy/path/
+        rule = "PathPrefix:" + routespec
+    else:
+        # Host-based routing, e.g. host.tld/proxy/path/
+        host, path_prefix = routespec.split("/", 1)
+        path_prefix = "/" + path_prefix
+        rule = "Host:" + host + ";PathPrefix:" + path_prefix
+
+    if not test_deletion:
+        expected_rv = frontend_rule_path + "\n" + rule
+    assert_etcdctl_get(frontend_rule_path, expected_rv)
+
+
+async def test_add_path_based_route_to_etcd(proxy):
+    routespec = "/proxy/path"
+    target = "http://127.0.0.1:99"
+    data = {"test": "test1"}
+
+    await proxy.add_route(routespec, target, data)
+
+    try:
+        check_route_with_etcdl(proxy, routespec, target, data)
+    finally:
+        await proxy.stop()
+
+
+async def test_add_host_based_route_to_etcd(proxy):
+    routespec = "host/proxy/path"
+    target = "http://127.0.0.1:909"
+    data = {"test": "test2"}
+
+    await proxy.add_route(routespec, target, data)
+
+    try:
+        # Test that (routespec, target) pair has been added to etcd
+        check_route_with_etcdl(proxy, routespec, target, data, False)
+    finally:
+        await proxy.stop()
+
+
+async def test_delete_route_from_etcd(proxy):
+    routespec = "/proxy/another_path"
+    target = "http://127.0.0.1:990"
+    data = {"test": "test3"}
+
+    add_route_with_etcdctl(proxy, routespec, target, data)
+    await proxy.delete_route("/proxy/another_path")
+    try:
+        # Test that (routespec, target) pair has been added to etcd
+        check_route_with_etcdl(proxy, routespec, target, data, True)
+    finally:
+        await proxy.stop()
 
 
 async def test_get_all_routes(proxy):
@@ -24,15 +174,19 @@ async def test_get_all_routes(proxy):
     # TODO: test the routes
 
 
-async def test_delete_route(proxy):
-    # with pytest.raises(NotImplementedError):
-    await proxy.delete_route("/prefix0")
-    await proxy.stop()
-
-
 async def test_get_route(proxy):
-    # with pytest.raises(NotImplementedError):
-    route = await proxy.get_route("/prefix")
-    print(json.dumps(route, sort_keys=True, indent=4, separators=(",", ": ")))
+    routespec = "/proxy/just_another_path"
+    target = "http://127.0.0.1:990"
+    data = {"test": "test4"}
+    expected_output = {
+        "routespec": routespec,
+        "target": target,
+        "data": json.dumps(data),
+    }
+
+    add_route_with_etcdctl(proxy, routespec, target, data)
+    route = await proxy.get_route(routespec)
+
+    assert route == expected_output
     await proxy.stop()
-    # TODO: test the route
+    # preety_formated_result = json.dumps(route, sort_keys=True, indent=4, separators=(",", ": "))


### PR DESCRIPTION
I added a new Proxy class (`TraefikEtcdProxy`) that uses `traefik` and `etcd` to store its configuration and follows the jupyterhub Proxy api.
For each route that we need to add to the Proxy, traefik needs a special configuration.
Thus, each time we call `proxy.add_route(routespec, target)` we'll add to `etcd` 6 key-value entries:


- **routespec** (with a prefix to know it was added by jupyterhub)  - **target**
   to be able to retrieve the route afterwards, given the routespec
- **target** - **data**
  the data will also be needed when retrieving a route
- **backend** - **target**
  add the target as a backend server
- **backend** - **weight**
  the weight will be used for load balancing
- **frontend** - **backend**
  we need a frontend associated with the previous added backend in order to set routing rules
- **frontend** - **rule** (based on the routespec)
  the routing rule (it supports both path-based and host-based routing)

Also, I didn't find another way of forcing `traefik` to reload its configuration from `etcd` apart from restarting it. I needed some way to synchronize the config loading phase when testing the routing is done right. @minrk please tell me if you can think of a more elegant way of doing this. Also, it would be great if you could review this PR and give me some feedback.
 