### PR TITLE
Etcd transaction and etcd3 async client

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 pytest
 pytest-asyncio
 etcd3
+aioetcd3
 requests
 codecov
 black

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 pytest
 pytest-asyncio
-aioetcd3
 requests
 codecov
 black

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 pytest
 pytest-asyncio
-etcd3
 aioetcd3
 requests
 codecov

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -67,7 +67,9 @@ class TraefikEtcdProxy(Proxy):
     async def _setup_etcd(self):
         self.log.info("Seting up etcd...")
         await self.etcd_client.put(self.etcd_traefik_prefix + "debug", "true")
-        await self.etcd_client.put(self.etcd_traefik_prefix + "defaultentrypoints/0", "http")
+        await self.etcd_client.put(
+            self.etcd_traefik_prefix + "defaultentrypoints/0", "http"
+        )
         await self.etcd_client.put(
             self.etcd_traefik_prefix + "entrypoints/http/address",
             ":" + str(self.traefik_port),
@@ -75,13 +77,17 @@ class TraefikEtcdProxy(Proxy):
         await self.etcd_client.put(self.etcd_traefik_prefix + "api/dashboard", "true")
         await self.etcd_client.put(self.etcd_traefik_prefix + "api/entrypoint", "http")
         await self.etcd_client.put(self.etcd_traefik_prefix + "loglevel", "ERROR")
-        await self.etcd_client.put(self.etcd_traefik_prefix + "etcd/endpoint", "127.0.0.1:2379")
+        await self.etcd_client.put(
+            self.etcd_traefik_prefix + "etcd/endpoint", "127.0.0.1:2379"
+        )
         await self.etcd_client.put(
             self.etcd_traefik_prefix + "etcd/prefix", self.etcd_traefik_prefix
         )
         await self.etcd_client.put(self.etcd_traefik_prefix + "etcd/useapiv3", "true")
         await self.etcd_client.put(self.etcd_traefik_prefix + "etcd/watch", "true")
-        await self.etcd_client.put(self.etcd_traefik_prefix + "providersThrottleDuration", "1")
+        await self.etcd_client.put(
+            self.etcd_traefik_prefix + "providersThrottleDuration", "1"
+        )
 
     def _start_traefik(self):
         self.log.info("Starting %s proxy...", self.command)
@@ -177,7 +183,7 @@ class TraefikEtcdProxy(Proxy):
                 KV.put.txn(backend_url_path, target),
                 KV.put.txn(backend_weight_path, "1"),
                 KV.put.txn(frontend_backend_path, backend_alias),
-                KV.put.txn(frontend_rule_path, rule)
+                KV.put.txn(frontend_rule_path, rule),
             ],
             fail=[],
         )

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -2,7 +2,6 @@ import time
 import socket
 import sys
 import requests
-import etcd3
 from os.path import abspath, dirname, join
 from subprocess import Popen
 from urllib.parse import urlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jupyterhub>=0.9
+aioetcd3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,11 @@ from jupyterhub_traefik_proxy import TraefikEtcdProxy
 async def proxy():
     """Fixture returning a configured Traefik Proxy"""
     proxy = TraefikEtcdProxy()
-    await proxy.start()
-    yield proxy
+    try:
+        await proxy.start()
+        yield proxy
+    finally:
+        await proxy.stop()
 
 
 @pytest.fixture

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -159,11 +159,8 @@ def check_route_with_etcdctl(proxy, routespec, target, data, test_deletion=False
 async def test_add_route_to_etcd(proxy, routespec, target, data):
     await proxy.add_route(routespec, target, data)
 
-    try:
-        check_route_with_etcdctl(proxy, routespec, target, data)
-        cleanup_test_route(proxy, routespec, target, data)
-    finally:
-        await proxy.stop()
+    check_route_with_etcdctl(proxy, routespec, target, data)
+    cleanup_test_route(proxy, routespec, target, data)
 
 
 @pytest.mark.parametrize(
@@ -179,11 +176,8 @@ async def test_delete_route_from_etcd(proxy, routespec, target, data):
     add_route_with_etcdctl(proxy, routespec, target, data)
     await proxy.delete_route(routespec)
 
-    try:
-        # Test that (routespec, target) pair has been added to etcd
-        check_route_with_etcdctl(proxy, routespec, target, data, True)
-    finally:
-        await proxy.stop()
+    # Test that (routespec, target) pair has been added to etcd
+    check_route_with_etcdctl(proxy, routespec, target, data, True)
 
 
 @pytest.mark.parametrize(
@@ -223,7 +217,6 @@ async def test_get_route(proxy, routespec, target, data, expected_output):
     cleanup_test_route(proxy, routespec, target, data)
 
     assert route == expected_output
-    await proxy.stop()
 
 
 async def test_get_all_routes(proxy):
@@ -260,7 +253,6 @@ async def test_get_all_routes(proxy):
         cleanup_test_route(proxy, routespec[0], target[0], data[0])
         cleanup_test_route(proxy, routespec[1], target[1], data[1])
         cleanup_test_route(proxy, routespec[2], target[2], data[2])
-        await proxy.stop()
 
 
 async def test_etcd_routing(proxy, restart_traefik_proc):
@@ -288,7 +280,6 @@ async def test_etcd_routing(proxy, restart_traefik_proc):
         default_backend.wait()
         first_backend.wait()
         second_backend.wait()
-        await proxy.stop()
         cleanup_test_route(proxy, routespec[0], target[0], data[0])
         cleanup_test_route(proxy, routespec[1], target[1], data[1])
         cleanup_test_route(proxy, routespec[2], target[2], data[2])


### PR DESCRIPTION
Regarding https://github.com/jupyterhub/traefik-proxy/issues/6  and https://github.com/jupyterhub/traefik-proxy/issues/5, the proxy now uses etcd transactions to add or delete all 6 KV entries associated with a route.

Also, the etcd v3 client is now async (https://github.com/gaopeiliang/aioetcd3)

@minrk, I will address the issues from the prev PR in a new one, thanks a lot for the feedback.

closes #5, #6, #9