### PR TITLE
Added sample jupyterhub config

### DIFF
--- a/examples/jupyterhub_config.py
+++ b/examples/jupyterhub_config.py
@@ -1,0 +1,15 @@
+"""sample jupyterhub config file for testing
+
+configures jupyterhub to run with traefik.
+
+configures jupyterhub with dummyauthenticator and simplespawner
+to enable testing without administrative privileges.
+
+requires jupyterhub 1.0.dev
+"""
+
+c.JupyterHub.proxy_class = "traefik"
+
+# use dummy and simple auth/spawner for testing
+c.JupyterHub.authenticator_class = "dummy"
+c.JupyterHub.spawner_class = "simple"

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -75,7 +75,7 @@ class TraefikEtcdProxy(Proxy):
                     self.etcd_traefik_prefix + "entrypoints/http/address",
                     ":" + str(urlparse(self.public_url).port),
                 ),
-                KV.put.txn(self.etcd_traefik_prefix + "api/dashboard", "true"),
+                KV.put.txn(self.etcd_traefik_prefix + "api/dashboard", "false"),
                 KV.put.txn(self.etcd_traefik_prefix + "api/entrypoint", "http"),
                 KV.put.txn(self.etcd_traefik_prefix + "loglevel", "ERROR"),
                 KV.put.txn(
@@ -206,7 +206,7 @@ class TraefikEtcdProxy(Proxy):
         )
 
         if status:
-            self.log.info("Added backend %s with the alias.", target, backend_alias)
+            self.log.info("Added backend %s with the alias %s.", target, backend_alias)
             self.log.info(
                 "Added frontend %s for backend %s with the following routing rule %s.",
                 frontend_alias,


### PR DESCRIPTION
Added sample jupyterhub_config.py. closes https://github.com/jupyterhub/traefik-proxy/issues/15.

I also disabled traefik's dashboard. When running jupyterhub with trafik, logs said
`JupyterHub is now running at http://127.0.0.1:8000/`.
When I checked this address from the browser, I was expecting to see  Jupyterhub as the logs said but instead traefik redirected me to it's dashboard. I had to explicitly put `http://127.0.0.1:8000/hub/` to take me to jupyterhub's login page. Disabling the dashboard fixes this behaviour. Traefk's documentation also advises not making the dashboard public as it may pose security concerns. @minrk , please let me know if you agree.