### PR TITLE
check for keys in dicts directly

### DIFF
--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -27,8 +27,8 @@ async def check_traefik_dynamic_conf_ready(traefik_url, target):
 
         if resp_backends.code == 200 and resp_frontends.code == 200:
             ready = (
-                expected_backend in backends_data.keys()
-                and expected_frontend in frontends_data.keys()
+                expected_backend in backends_data
+                and expected_frontend in frontends_data
             )
     except Exception as e:
         backends_rc, frontends_rc = e.response.code


### PR DESCRIPTION
when checking for the presence of a key in a dictionary, we can use `key in dict` directly, without producing the keys list first