### PR TITLE
TraefikTomlProxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 
 # installing dependencies
 before_install:
+  - pip install --upgrade pytest
   - pip install --upgrade setuptools pip
   - pip install --pre -r dev-requirements.txt
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
   - pip install --pre -r dev-requirements.txt
 install:
   - pip install --pre -r dev-requirements.txt .
-  - pip install pytest-travis-fold
   - python -m jupyterhub_traefik_proxy.install --output=./bin
   - export PATH=$PWD/bin:$PATH
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 # installing dependencies
 before_install:
   - pip install --upgrade setuptools pip
-  - pip install --pre -r dev-requirements.txt --upgrade
+  - pip install --pre -r dev-requirements.txt --upgrade .
 install:
   - python -m jupyterhub_traefik_proxy.install --output=./bin
   - export PATH=$PWD/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 # installing dependencies
 before_install:
   - pip install --upgrade setuptools pip
-  - pip install --pre -r --upgrade dev-requirements.txt
+  - pip install --pre -r dev-requirements.txt --upgrade
 install:
   - python -m jupyterhub_traefik_proxy.install --output=./bin
   - export PATH=$PWD/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,9 @@ env:
 
 # installing dependencies
 before_install:
-  - pip install --upgrade pytest
   - pip install --upgrade setuptools pip
-  - pip install --pre -r dev-requirements.txt
+  - pip install --pre -r --upgrade dev-requirements.txt
 install:
-  - pip install --pre -r dev-requirements.txt .
   - python -m jupyterhub_traefik_proxy.install --output=./bin
   - export PATH=$PWD/bin:$PATH
   - pip freeze

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -16,13 +16,13 @@ Module: :mod:`jupyterhub_traefik_proxy`
     :members:
 
 :class:`TraefikEtcdProxy`
----------------------
+-------------------------
 
 .. autoconfigurable:: TraefikEtcdProxy
     :members:
 
 :class:`TraefikTomlProxy`
----------------------
+-------------------------
 
 .. autoconfigurable:: TraefikTomlProxy
     :members:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -20,3 +20,9 @@ Module: :mod:`jupyterhub_traefik_proxy`
 
 .. autoconfigurable:: TraefikEtcdProxy
     :members:
+
+:class:`TraefikTomlProxy`
+---------------------
+
+.. autoconfigurable:: TraefikTomlProxy
+    :members:

--- a/jupyterhub_traefik_proxy/__init__.py
+++ b/jupyterhub_traefik_proxy/__init__.py
@@ -2,6 +2,7 @@
 
 from .proxy import TraefikProxy  # noqa
 from .etcd import TraefikEtcdProxy
+from .toml import TraefikTomlProxy
 
 from ._version import get_versions
 

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -168,7 +168,7 @@ class TraefikEtcdProxy(TraefikProxy):
 
         # To be able to delete the route when routespec is provided
         jupyterhub_routespec = self.etcd_jupyterhub_prefix + routespec
-        
+
         status, response = await self.etcd_client.txn(
             compare=[],
             success=[

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -60,6 +60,8 @@ class TraefikEtcdProxy(TraefikProxy):
     )
 
     async def _setup_traefik_static_config(self):
+        self._generate_htpassword()
+
         await super()._setup_traefik_static_config()
         keys = []
         values = []

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -60,8 +60,6 @@ class TraefikEtcdProxy(TraefikProxy):
     )
 
     async def _setup_traefik_static_config(self):
-        self._generate_htpassword()
-
         await super()._setup_traefik_static_config()
         keys = []
         values = []

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -18,7 +18,6 @@ Route Specification:
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import asyncio
 import json
 import os
 import hashlib
@@ -207,14 +206,14 @@ class TraefikEtcdProxy(Proxy):
 
         self.log.info("Adding route for %s to %s.", routespec, target)
 
-        backend_alias = traefik_utils.create_backend_alias_from_url(target)
+        backend_alias = traefik_utils.create_alias(target, "backend")
         backend_url_path = traefik_utils.create_backend_entry(
             self, backend_alias, url=True
         )
         backend_weight_path = traefik_utils.create_backend_entry(
             self, backend_alias, weight=True
         )
-        frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+        frontend_alias = traefik_utils.create_alias(target, "frontend")
         frontend_backend_path = traefik_utils.create_frontend_backend_entry(
             self, frontend_alias
         )
@@ -284,8 +283,8 @@ class TraefikEtcdProxy(Proxy):
             return
 
         target = value.decode()
-        backend_alias = traefik_utils.create_backend_alias_from_url(target)
-        frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
+        backend_alias = traefik_utils.create_alias(target, routespec, "backend")
+        frontend_alias = traefik_utils.create_alias(target, "frontend")
         backend_url_path = traefik_utils.create_backend_entry(
             self, backend_alias, url=True
         )

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -19,15 +19,13 @@ Route Specification:
 # Distributed under the terms of the Modified BSD License.
 
 import json
-import os
-import base64
-
 from urllib.parse import urlparse
+from traitlets import Any, default, Unicode
+
 from aioetcd3.client import client
 from aioetcd3 import transaction
 from aioetcd3.kv import KV
 from aioetcd3.help import range_prefix
-from traitlets import Any, default, Unicode
 
 from . import traefik_utils
 from jupyterhub_traefik_proxy import TraefikProxy
@@ -99,10 +97,15 @@ class TraefikEtcdProxy(TraefikProxy):
             fail=[],
         )
 
+        if status:
+            self.log.error(
+                "Couldn't set up traefik's static config. Response: %s", response
+            )
+
     def _start_traefik(self):
         self.log.info("Starting traefik...")
         try:
-            self.traefik_process = traefik_utils.launch_traefik_with_etcd()
+            self._launch_traefik(config_type="etcd")
         except FileNotFoundError as e:
             self.log.error(
                 "Failed to find traefik \n"
@@ -314,5 +317,4 @@ class TraefikEtcdProxy(TraefikProxy):
         else:
             data = value.decode()
 
-        result = {"routespec": routespec, "target": target, "data": data}
-        return result
+        return {"routespec": routespec, "target": target, "data": data}

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -92,7 +92,6 @@ class TraefikEtcdProxy(TraefikProxy):
                 for i in range(len(value)):
                     key += "/" + str(i)
                     value = value[i]
-            print(key + " = " + str(value))
             success.append(KV.put.txn(key.lower(), value))
 
         status, response = await self.etcd_client.txn(

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -74,9 +74,11 @@ class TraefikEtcdProxy(Proxy):
     traefik_api_password = Unicode(
         config=True, help="""The password for traefik api login"""
     )
+
     traefik_api_username = Unicode(
         config=True, help="""The username for traefik api login"""
     )
+
     traefik_api_hashed_password = Unicode()
 
     def _create_htpassword(self):
@@ -206,22 +208,24 @@ class TraefikEtcdProxy(Proxy):
         self.log.info("Adding route for %s to %s.", routespec, target)
 
         backend_alias = traefik_utils.create_backend_alias_from_url(target)
-        backend_url_path = traefik_utils.create_backend_url_path(self, backend_alias)
-        backend_weight_path = traefik_utils.create_backend_weight_path(
-            self, backend_alias
+        backend_url_path = traefik_utils.create_backend_entry(
+            self, backend_alias, url=True
+        )
+        backend_weight_path = traefik_utils.create_backend_entry(
+            self, backend_alias, weight=True
         )
         frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
-        frontend_backend_path = traefik_utils.create_frontend_backend_path(
+        frontend_backend_path = traefik_utils.create_frontend_backend_entry(
             self, frontend_alias
         )
-        frontend_rule_path = traefik_utils.create_frontend_rule_path(
+        frontend_rule_path = traefik_utils.create_frontend_rule_entry(
             self, frontend_alias
         )
 
         # To be able to delete the route when routespec is provided
         jupyterhub_routespec = self.etcd_jupyterhub_prefix + routespec
         # Store the data dict passed in by JupyterHub
-        encoded_data = data = json.dumps(data)
+        data = json.dumps(data)
 
         if routespec.startswith("/"):
             # Path-based route, e.g. /proxy/path/
@@ -236,7 +240,7 @@ class TraefikEtcdProxy(Proxy):
             compare=[],
             success=[
                 KV.put.txn(jupyterhub_routespec, target),
-                KV.put.txn(target, encoded_data),
+                KV.put.txn(target, data),
                 KV.put.txn(backend_url_path, target),
                 KV.put.txn(backend_weight_path, "1"),
                 KV.put.txn(frontend_backend_path, backend_alias),
@@ -282,14 +286,16 @@ class TraefikEtcdProxy(Proxy):
         target = value.decode()
         backend_alias = traefik_utils.create_backend_alias_from_url(target)
         frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
-        backend_url_path = traefik_utils.create_backend_url_path(self, backend_alias)
-        backend_weight_path = traefik_utils.create_backend_weight_path(
-            self, backend_alias
+        backend_url_path = traefik_utils.create_backend_entry(
+            self, backend_alias, url=True
         )
-        frontend_backend_path = traefik_utils.create_frontend_backend_path(
+        backend_weight_path = traefik_utils.create_backend_entry(
+            self, backend_alias, weight=True
+        )
+        frontend_backend_path = traefik_utils.create_frontend_backend_entry(
             self, frontend_alias
         )
-        frontend_rule_path = traefik_utils.create_frontend_rule_path(
+        frontend_rule_path = traefik_utils.create_frontend_rule_entry(
             self, frontend_alias
         )
 

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -64,12 +64,12 @@ class TraefikProxy(Proxy):
         ht.set_password(self.traefik_api_username, self.traefik_api_password)
         self.traefik_api_hashed_password = str(ht.to_string()).split(":")[1][:-3]
 
-    async def _wait_for_route(self, target, provider):
+    async def _wait_for_route(self, routespec, provider):
         async def _check_traefik_dynamic_conf_ready():
             """ Check if traefik loaded its dynamic configuration from the
                 etcd cluster """
-            expected_backend = traefik_utils.generate_alias(target, "backend")
-            expected_frontend = traefik_utils.generate_alias(target, "frontend")
+            expected_backend = traefik_utils.generate_alias(routespec, "backend")
+            expected_frontend = traefik_utils.generate_alias(routespec, "frontend")
             ready = False
             try:
                 resp_backends = await AsyncHTTPClient().fetch(
@@ -98,7 +98,7 @@ class TraefikProxy(Proxy):
 
         await exponential_backoff(
             _check_traefik_dynamic_conf_ready,
-            "Traefik route for %s configuration not available" % target,
+            "Traefik route for %s configuration not available" % routespec,
             timeout=20,
         )
 

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -57,7 +57,6 @@ class TraefikProxy(Proxy):
         ht.set_password(self.traefik_api_username, self.traefik_api_password)
         self.traefik_api_hashed_password = str(ht.to_string()).split(":")[1][:-3]
 
-
     async def _wait_for_route(self, target, provider):
         async def _check_traefik_dynamic_conf_ready():
             """ Check if traefik loaded its dynamic configuration from the

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -149,7 +149,6 @@ class TraefikProxy(Proxy):
 
     async def _setup_traefik_static_config(self):
         self.log.info("Setting up traefik's static config...")
-        self._generate_htpassword()
 
         self.static_config = {}
         self.static_config["defaultentrypoints"] = ["http"]

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -149,6 +149,7 @@ class TraefikProxy(Proxy):
 
     async def _setup_traefik_static_config(self):
         self.log.info("Setting up traefik's static config...")
+        self._generate_htpassword()
 
         self.static_config = {}
         self.static_config["defaultentrypoints"] = ["http"]
@@ -166,11 +167,6 @@ class TraefikProxy(Proxy):
         entryPoints["auth_api"] = {
             "address": ":" + str(urlparse(self.traefik_api_url).port),
             "auth": auth,
-        }
-        entryPoints["auth_api"]["auth"]["basic"] = {
-            "users": [
-                self.traefik_api_username + ":" + self.traefik_api_hashed_password
-            ]
         }
         self.static_config["entryPoints"] = entryPoints
         self.static_config["api"] = {"dashboard": True, "entrypoint": "auth_api"}

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -58,9 +58,13 @@ class TraefikTomlProxy(TraefikProxy):
         self.static_config["file"] = {"filename": "rules.toml", "watch": True}
 
         try:
-            traefik_utils.persist_static_conf(self.toml_static_config_file, self.static_config)
+            traefik_utils.persist_static_conf(
+                self.toml_static_config_file, self.static_config
+            )
             try:
-                traefik_utils.load_routes(self.toml_dynamic_config_file, self.routes_cache)
+                traefik_utils.load_routes(
+                    self.toml_dynamic_config_file, self.routes_cache
+                )
             except FileNotFoundError:
                 # Make sure that the dynamic configuration file exists
                 open(self.toml_dynamic_config_file, "a").close()
@@ -176,7 +180,9 @@ class TraefikTomlProxy(TraefikProxy):
             self.routes_cache["backends"][route_keys.backend_alias] = {
                 "servers": {"server1": {"url": target, "weight": 1}}
             }
-            traefik_utils.persist_routes(self.toml_dynamic_config_file, self.routes_cache)
+            traefik_utils.persist_routes(
+                self.toml_dynamic_config_file, self.routes_cache
+            )
 
         if not self.should_start:
             try:

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -52,6 +52,8 @@ class TraefikTomlProxy(TraefikProxy):
         self.routes_cache = {}
 
     async def _setup_traefik_static_config(self):
+        self._generate_htpassword()
+
         await super()._setup_traefik_static_config()
 
         self.static_config["file"] = {"filename": "rules.toml", "watch": True}

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -64,9 +64,7 @@ class TraefikTomlProxy(TraefikProxy):
         except IOError:
             self.log.exception("Couldn't set up traefik's static config.")
         except:
-            self.log.error(
-                "Couldn't set up traefik's static config. Unexpected error:",
-            )
+            self.log.error("Couldn't set up traefik's static config. Unexpected error:")
 
     def _start_traefik(self):
         self.log.info("Starting traefik...")

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -216,6 +216,7 @@ class TraefikTomlProxy(TraefikProxy):
                     "\t\tpassHostHeader = true\n",
                     "\t\t[" + frontend_rule_path + "]\n",
                     "\t\t\trule = " + '"' + rule + '"\n',
+                    "\t\t\tdata = " + "'" + data + "'\n",
                 ],
                 "data": data,
                 "target": target,

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -61,12 +61,8 @@ class TraefikTomlProxy(TraefikProxy):
             with open(self.toml_static_config_file, "w") as f:
                 f.write(toml_string)
             open(self.toml_dynamic_config_file, "a").close()
-        except IOError as e:
-            self.log.error(
-                "Couldn't set up traefik's static config. I/O error({0}): {1}".format(
-                    e.errno, e.strerrornse
-                )
-            )
+        except IOError:
+            self.log.exception("Couldn't set up traefik's static config.")
         except:
             self.log.error(
                 "Couldn't set up traefik's static config. Unexpected error:",

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -1,0 +1,273 @@
+"""Traefik implementation
+
+Custom proxy implementations can subclass :class:`Proxy`
+and register in JupyterHub config:
+
+.. sourcecode:: python
+
+    from mymodule import MyProxy
+    c.JupyterHub.proxy_class = MyProxy
+
+Route Specification:
+
+- A routespec is a URL prefix ([host]/path/), e.g.
+  'host.tld/path/' for host-based routing or '/path/' for default routing.
+- Route paths should be normalized to always start and end with '/'
+"""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import json
+import os
+
+from urllib.parse import urlparse
+from traitlets import Any, default, Unicode
+
+from . import traefik_utils
+from jupyterhub.proxy import Proxy
+
+
+class TraefikTomlProxy(Proxy):
+    """JupyterHub Proxy implementation using traefik and toml config file"""
+
+    traefik_process = Any()
+
+    toml_static_config_file = Unicode(
+        "traefik.toml", config=True, help="""traefik's configuration file"""
+    )
+
+    toml_dynamic_config_file = Unicode(
+        "rules.toml", config=True, help="""traefik's configuration file"""
+    )
+
+    traefik_api_url = Unicode(
+        "http://127.0.0.1:8099",
+        config=True,
+        help="""traefik authenticated api endpoint url""",
+    )
+
+    traefik_api_password = Unicode(
+        config=True, help="""The password for traefik api login"""
+    )
+
+    traefik_api_username = Unicode(
+        config=True, help="""The username for traefik api login"""
+    )
+
+    traefik_api_hashed_password = Unicode()
+
+    routes_cache = {}
+
+    def _create_htpassword(self):
+        from passlib.apache import HtpasswdFile
+
+        ht = HtpasswdFile()
+        ht.set_password(self.traefik_api_username, self.traefik_api_password)
+        self.traefik_api_hashed_password = str(ht.to_string()).split(":")[1][:-3]
+
+    async def _setup_traefik_static_config(self):
+        self.log.info("Setting up traefik's static config...")
+        self._create_htpassword()
+
+        with open(self.toml_static_config_file, "w") as f:
+            f.write('defaultEntryPoints = ["http"]\n')
+            f.write("debug = true\n"),
+            f.write('logLevel = "ERROR"\n')
+
+            f.write("[entryPoints]\n"),
+            f.write("\t[entryPoints.http]\n")
+            f.write('\t\taddress = ":' + str(urlparse(self.public_url).port) + '"\n')
+            f.write("[entryPoints.auth_api]\n")
+            f.write(
+                '\t\taddress = ":' + str(urlparse(self.traefik_api_url).port) + '"\n'
+            )
+            f.write("\t\t[entryPoints.auth_api.auth]\n")
+            f.write("\t\t\t[entryPoints.auth_api.auth.basic]\n")
+            f.write(
+                '\t\t\t\tusers = ["'
+                + self.traefik_api_username
+                + ":"
+                + self.traefik_api_hashed_password
+                + '"]\n'
+            )
+
+            f.write("[api]\n"),
+            f.write("\tdashboard = true\n"),
+            f.write('\tentrypoint = "auth_api"\n'),
+
+            f.write("[file]\n")
+            f.write('\tfilename = "' + self.toml_dynamic_config_file + '"\n')
+            f.write("\twatch = true\n")
+            f.close()
+
+    def _start_traefik(self):
+        self.log.info("Starting traefik...")
+        try:
+            self.traefik_process = traefik_utils.launch_traefik_with_toml()
+        except FileNotFoundError as e:
+            self.log.error(
+                "Failed to find traefik \n"
+                "The proxy can be downloaded from https://github.com/containous/traefik/releases/download."
+            )
+            raise
+
+    def _stop_traefik(self):
+        self.log.info("Cleaning up proxy[%i]...", self.traefik_process.pid)
+        self.traefik_process.kill()
+        self.traefik_process.wait()
+
+    def _update_config_file(self):
+        tmp = open("tmp.toml", "w")
+        self._write_routes_to_file(tmp)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.rename("tmp.toml", self.toml_dynamic_config_file)
+
+    def _write_routes_to_file(self, config_fd):
+        config_fd.write("[frontends]\n")
+        for key, value in self.routes_cache.items():
+            config_fd.write("".join(value["frontend"]))
+        config_fd.write("[backends]\n")
+        for key, value in self.routes_cache.items():
+            config_fd.write("".join(value["backend"]))
+
+    async def start(self):
+        """Start the proxy.
+
+        Will be called during startup if should_start is True.
+
+        **Subclasses must define this method**
+        if the proxy is to be started by the Hub
+        """
+        self._start_traefik()
+        await self._setup_traefik_static_config()
+
+    async def stop(self):
+        """Stop the proxy.
+
+        Will be called during teardown if should_start is True.
+
+        **Subclasses must define this method**
+        if the proxy is to be started by the Hub
+        """
+        self._stop_traefik()
+
+    async def add_route(self, routespec, target, data):
+        """Add a route to the proxy.
+
+        **Subclasses must define this method**
+
+        Args:
+            routespec (str): A URL prefix ([host]/path/) for which this route will be matched,
+                e.g. host.name/path/
+            target (str): A full URL that will be the target of this route.
+            data (dict): A JSONable dict that will be associated with this route, and will
+                be returned when retrieving information about this route.
+
+        Will raise an appropriate Exception (FIXME: find what?) if the route could
+        not be added.
+
+        The proxy implementation should also have a way to associate the fact that a
+        route came from JupyterHub.
+        """
+
+        self.log.info("Adding route for %s to %s.", routespec, target)
+
+        backend_alias = traefik_utils.create_alias(target, routespec, "backend")
+        backend_url_path = traefik_utils.create_backend_entry(
+            self, backend_alias, separator="."
+        )
+        frontend_alias = traefik_utils.create_alias(target, routespec, "frontend")
+        frontend_rule_path = traefik_utils.create_frontend_rule_entry(
+            self, frontend_alias, separator="."
+        )
+        data = json.dumps(data)
+
+        if routespec.startswith("/"):
+            # Path-based route, e.g. /proxy/path/
+            rule = "PathPrefix:" + routespec
+        else:
+            # Host-based routing, e.g. host.tld/proxy/path/
+            host, path_prefix = routespec.split("/", 1)
+            path_prefix = "/" + path_prefix
+            rule = "Host:" + host + ";PathPrefix:" + path_prefix
+
+        self.routes_cache[routespec] = {
+            "backend": [
+                "\t[backends." + backend_alias + "]\n",
+                "\t\t[" + backend_url_path + "]\n",
+                "\t\t\turl = " + '"' + target + '"\n',
+                "\t\t\tweight = " + "1\n",
+            ],
+            "frontend": [
+                "\t[frontends." + frontend_alias + "]\n",
+                "\t\tbackend = " + '"' + backend_alias + '"\n',
+                "\t\t[" + frontend_rule_path.rsplit(".", 1)[0] + "]\n",
+                "\t\t\trule = " + '"' + rule + '"\n',
+            ],
+            "data": data,
+            "target": target,
+        }
+        self._update_config_file()
+
+    async def delete_route(self, routespec):
+        """Delete a route with a given routespec if it exists.
+
+        **Subclasses must define this method**
+        """
+        del self.routes_cache[routespec]
+        self._update_config_file()
+
+    async def get_all_routes(self):
+        """Fetch and return all the routes associated by JupyterHub from the
+        proxy.
+
+        **Subclasses must define this method**
+
+        Should return a dictionary of routes, where the keys are
+        routespecs and each value is a dict of the form::
+
+          {
+            'routespec': the route specification ([host]/path/)
+            'target': the target host URL (proto://host) for this route
+            'data': the attached data dict for this route (as specified in add_route)
+          }
+        """
+        all_routes = {}
+        for key, value in self.routes_cache.items():
+            all_routes[key] = {
+                "routespec": key,
+                "target": value["target"],
+                "data": value["data"],
+            }
+
+        return all_routes
+
+    async def get_route(self, routespec):
+        """Return the route info for a given routespec.
+
+        Args:
+            routespec (str):
+                A URI that was used to add this route,
+                e.g. `host.tld/path/`
+
+        Returns:
+            result (dict):
+                dict with the following keys::
+
+                'routespec': The normalized route specification passed in to add_route
+                    ([host]/path/)
+                'target': The target host for this route (proto://host)
+                'data': The arbitrary data dict that was passed in by JupyterHub when adding this
+                        route.
+
+            None: if there are no routes matching the given routespec
+        """
+        result = {
+            "routespec": routespec,
+            "target": self.routes_cache[routespec]["target"],
+            "data": self.routes_cache[routespec]["data"],
+        }
+        return result

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -52,8 +52,6 @@ class TraefikTomlProxy(TraefikProxy):
         self.routes_cache = {}
 
     async def _setup_traefik_static_config(self):
-        self._generate_htpassword()
-
         await super()._setup_traefik_static_config()
 
         self.static_config["file"] = {"filename": "rules.toml", "watch": True}

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -7,6 +7,7 @@ import os
 
 from urllib.parse import urlparse
 from contextlib import contextmanager
+from collections import namedtuple
 
 
 def generate_rule(routespec):
@@ -74,27 +75,39 @@ def generate_route_keys(proxy, target, routespec, separator=""):
     backend_alias = generate_alias(target, "backend")
     frontend_alias = generate_alias(target, "frontend")
 
+    RouteKeys = namedtuple(
+        "RouteKeys",
+        [
+            "backend_alias",
+            "backend_url_path",
+            "backend_weight_path",
+            "frontend_alias",
+            "frontend_backend_path",
+            "frontend_rule_path",
+        ],
+    )
+
     if separator != ".":
         backend_url_path = generate_backend_entry(proxy, backend_alias, url=True)
         frontend_rule_path = generate_frontend_rule_entry(proxy, frontend_alias)
         backend_weight_path = generate_backend_entry(proxy, backend_alias, weight=True)
         frontend_backend_path = generate_frontend_backend_entry(proxy, frontend_alias)
-        return (
-            backend_alias,
-            backend_url_path,
-            backend_weight_path,
-            frontend_alias,
-            frontend_backend_path,
-            frontend_rule_path,
+    else:
+        backend_url_path = generate_backend_entry(proxy, backend_alias, separator=separator)
+        frontend_rule_path = generate_frontend_rule_entry(
+            proxy, frontend_alias, separator=separator
         )
+        backend_weight_path = ""
+        frontend_backend_path = ""
 
-    backend_url_path = generate_backend_entry(proxy, backend_alias, separator=separator)
-    frontend_rule_path = generate_frontend_rule_entry(
-        proxy, frontend_alias, separator=separator
+    return RouteKeys(
+        backend_alias,
+        backend_url_path,
+        backend_weight_path,
+        frontend_alias,
+        frontend_backend_path,
+        frontend_rule_path,
     )
-
-    return (backend_alias, backend_url_path, frontend_alias, frontend_rule_path)
-
 
 def path_to_intermediate(path):
     """Name of the intermediate file used in atomic writes.

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -131,13 +131,16 @@ def atomic_writing(path):
     # Written successfully, now remove the backup copy
     os.remove(tmp_path)
 
+
 def persist_static_conf(file, static_conf_dict):
     with open(file, "w") as f:
         toml.dump(static_conf_dict, f)
 
+
 def persist_routes(file, routes_dict):
     with atomic_writing(file) as config_fd:
         toml.dump(routes_dict, config_fd)
+
 
 def load_routes(file, routes_dict):
     with open(file, "r") as config_fd:

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -2,24 +2,7 @@ import sys
 import json
 import re
 
-from os.path import abspath, dirname, join
-from subprocess import Popen
 from urllib.parse import urlparse
-
-
-def launch_traefik_with_toml():
-    config_file_path = abspath(join(dirname(__file__), "../traefik.toml"))
-    traefik = Popen(["traefik", "-c", config_file_path], stdout=None)
-    return traefik
-
-
-def launch_traefik_with_etcd():
-    traefik = Popen(["traefik", "--etcd", "--etcd.useapiv3=true"], stdout=None)
-    return traefik
-
-
-def replace_special_chars(string):
-    return re.sub("[.:/]", "_", string)
 
 
 def generate_rule(routespec):
@@ -35,7 +18,7 @@ def generate_rule(routespec):
 
 
 def generate_alias(url, server_type=""):
-    return server_type + replace_special_chars(urlparse(url).netloc)
+    return server_type + re.sub("[.:/]", "_", (urlparse(url).netloc))
 
 
 def generate_backend_entry(

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -32,15 +32,7 @@ def generate_backend_entry(
     backend_entry = ""
     if separator is "/":
         backend_entry = proxy.etcd_traefik_prefix
-    backend_entry += (
-        "backends"
-        + separator
-        + backend_alias
-        + separator
-        + "servers"
-        + separator
-        + "server1"
-    )
+    backend_entry += separator.join(["backends", backend_alias, "servers", "server1"])
     if url is True:
         backend_entry += separator + "url"
     elif weight is True:
@@ -54,14 +46,8 @@ def generate_frontend_backend_entry(proxy, frontend_alias):
 
 
 def generate_frontend_rule_entry(proxy, frontend_alias, separator="/"):
-    frontend_rule_entry = (
-        "frontends"
-        + separator
-        + frontend_alias
-        + separator
-        + "routes"
-        + separator
-        + "test"
+    frontend_rule_entry = separator.join(
+        ["frontends", frontend_alias, "routes", "test"]
     )
     if separator == "/":
         frontend_rule_entry = (
@@ -93,7 +79,9 @@ def generate_route_keys(proxy, target, routespec, separator=""):
         backend_weight_path = generate_backend_entry(proxy, backend_alias, weight=True)
         frontend_backend_path = generate_frontend_backend_entry(proxy, frontend_alias)
     else:
-        backend_url_path = generate_backend_entry(proxy, backend_alias, separator=separator)
+        backend_url_path = generate_backend_entry(
+            proxy, backend_alias, separator=separator
+        )
         frontend_rule_path = generate_frontend_rule_entry(
             proxy, frontend_alias, separator=separator
         )
@@ -108,6 +96,7 @@ def generate_route_keys(proxy, target, routespec, separator=""):
         frontend_backend_path,
         frontend_rule_path,
     )
+
 
 def path_to_intermediate(path):
     """Name of the intermediate file used in atomic writes.

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -5,57 +5,6 @@ import re
 from os.path import abspath, dirname, join
 from subprocess import Popen
 from urllib.parse import urlparse
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
-
-
-async def check_traefik_dynamic_conf_ready(username, password, api_url, target, provider="etcdv3"):
-    """ Check if traefik loaded its dynamic configuration from the
-        etcd cluster """
-    expected_backend = create_alias(target, "backend")
-    expected_frontend = create_alias(target, "frontend")
-    ready = False
-    try:
-        resp_backends = await AsyncHTTPClient().fetch(
-            api_url + "/api/providers/" + provider + "/backends",
-            auth_username=username,
-            auth_password=password,
-        )
-        resp_frontends = await AsyncHTTPClient().fetch(
-            api_url + "/api/providers/" + provider + "/frontends",
-            auth_username=username,
-            auth_password=password,
-        )
-        backends_data = json.loads(resp_backends.body)
-        frontends_data = json.loads(resp_frontends.body)
-
-        if resp_backends.code == 200 and resp_frontends.code == 200:
-            ready = (
-                expected_backend in backends_data
-                and expected_frontend in frontends_data
-            )
-    except Exception as e:
-        backends_rc, frontends_rc = e.response.code
-        ready = False
-    finally:
-        return ready
-
-
-async def check_traefik_static_conf_ready(username, password, api_url, provider="etcdv3"):
-    """ Check if traefik loaded its static configuration from the
-    etcd cluster """
-    try:
-        resp = await AsyncHTTPClient().fetch(
-            api_url + "/api/providers/" + provider,
-            auth_username=username,
-            auth_password=password,
-        )
-        rc = resp.code
-    except ConnectionRefusedError:
-        rc = None
-    except Exception as e:
-        rc = e.response.code
-    finally:
-        return rc == 200
 
 
 def launch_traefik_with_toml():
@@ -69,22 +18,29 @@ def launch_traefik_with_etcd():
     return traefik
 
 
-def generate_traefik_toml():
-    pass  # Not implemented
-
-
 def replace_special_chars(string):
     return re.sub("[.:/]", "_", string)
 
 
-def create_alias(url, server_type=""):
-    return (
-        server_type
-        + replace_special_chars(urlparse(url).netloc)
-    )
+def generate_rule(routespec):
+    if routespec.startswith("/"):
+        # Path-based route, e.g. /proxy/path/
+        rule = "PathPrefix:" + routespec
+    else:
+        # Host-based routing, e.g. host.tld/proxy/path/
+        host, path_prefix = routespec.split("/", 1)
+        path_prefix = "/" + path_prefix
+        rule = "Host:" + host + ";PathPrefix:" + path_prefix
+    return rule
 
 
-def create_backend_entry(proxy, backend_alias, separator="/", url=False, weight=False):
+def generate_alias(url, server_type=""):
+    return server_type + replace_special_chars(urlparse(url).netloc)
+
+
+def generate_backend_entry(
+    proxy, backend_alias, separator="/", url=False, weight=False
+):
     backend_entry = ""
     if separator is "/":
         backend_entry = proxy.etcd_traefik_prefix
@@ -105,15 +61,12 @@ def create_backend_entry(proxy, backend_alias, separator="/", url=False, weight=
     return backend_entry
 
 
-def create_frontend_backend_entry(proxy, frontend_alias):
+def generate_frontend_backend_entry(proxy, frontend_alias):
     return proxy.etcd_traefik_prefix + "frontends/" + frontend_alias + "/backend"
 
 
-def create_frontend_rule_entry(proxy, frontend_alias, separator="/"):
-    frontend_rule_entry = ""
-    if separator == "/":
-        frontend_rule_entry = proxy.etcd_traefik_prefix
-    frontend_rule_entry += (
+def generate_frontend_rule_entry(proxy, frontend_alias, separator="/"):
+    frontend_rule_entry = (
         "frontends"
         + separator
         + frontend_alias
@@ -121,8 +74,36 @@ def create_frontend_rule_entry(proxy, frontend_alias, separator="/"):
         + "routes"
         + separator
         + "test"
-        + separator
-        + "rule"
     )
+    if separator == "/":
+        frontend_rule_entry = (
+            proxy.etcd_traefik_prefix + frontend_rule_entry + separator + "rule"
+        )
 
     return frontend_rule_entry
+
+
+def generate_route_keys(proxy, target, routespec, separator=""):
+    backend_alias = generate_alias(target, "backend")
+    frontend_alias = generate_alias(target, "frontend")
+
+    if separator != ".":
+        backend_url_path = generate_backend_entry(proxy, backend_alias, url=True)
+        frontend_rule_path = generate_frontend_rule_entry(proxy, frontend_alias)
+        backend_weight_path = generate_backend_entry(proxy, backend_alias, weight=True)
+        frontend_backend_path = generate_frontend_backend_entry(proxy, frontend_alias)
+        return (
+            backend_alias,
+            backend_url_path,
+            backend_weight_path,
+            frontend_alias,
+            frontend_backend_path,
+            frontend_rule_path,
+        )
+
+    backend_url_path = generate_backend_entry(proxy, backend_alias, separator=separator)
+    frontend_rule_path = generate_frontend_rule_entry(
+        proxy, frontend_alias, separator=separator
+    )
+
+    return (backend_alias, backend_url_path, frontend_alias, frontend_rule_path)

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -142,6 +142,9 @@ def persist_routes(file, routes_dict):
         toml.dump(routes_dict, config_fd)
 
 
-def load_routes(file, routes_dict):
-    with open(file, "r") as config_fd:
-        toml.load(routes_dict, config_fd)
+def load_routes(file):
+    try:
+        with open(file, "r") as config_fd:
+            return toml.load(config_fd)
+    except:
+        raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jupyterhub>=0.9
 aioetcd3
 passlib
 toml
+escapism

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jupyterhub>=0.9
 aioetcd3
 passlib
+toml

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ setup(
     include_package_data=True,
     cmdclass=cmdclass,
     entry_points={
-        "jupyterhub.proxies": ["traefik = jupyterhub_traefik_proxy:TraefikEtcdProxy"]
+        "jupyterhub.proxies": [
+            "traefik = jupyterhub_traefik_proxy:TraefikEtcdProxy",
+            "traefik_toml = jupyterhub_traefik_proxy:TraefikTomlProxy",
+        ]
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,51 +12,35 @@ from jupyterhub_traefik_proxy import TraefikTomlProxy
 from os.path import abspath, dirname, join
 
 
-def create_etcd_proxy():
-    """Function returning a TraefikEtcdProxy object"""
+@pytest.fixture()
+async def etcd_proxy():
+    """Fixture returning a configured TraefikEtcdProxy"""
     proxy = TraefikEtcdProxy(
         public_url="http://127.0.0.1:8000",
         traefik_api_password="admin",
         traefik_api_username="api_admin",
     )
-    return proxy
-
-
-def create_toml_proxy():
-    """Function returning a TraefikTomlProxy object"""
-    proxy = TraefikTomlProxy(
-        public_url="http://127.0.0.1:8000",
-        traefik_api_password="admin",
-        traefik_api_username="api_admin",
-    )
-    return proxy
-
-
-@pytest.fixture(params=[create_etcd_proxy, create_toml_proxy])
-async def proxy(request):
-    """Fixture returning a configured Traefik Proxy"""
-    proxy = request.param()
     await proxy.start()
     yield proxy
     await proxy.stop()
 
 
 @pytest.fixture()
-async def etcd_proxy():
-    """Fixture returning a configured Traefik Proxy"""
-    proxy = create_etcd_proxy()
-    await proxy.start()
-    yield proxy
-    # await proxy.stop()
-
-
-@pytest.fixture()
 async def toml_proxy():
-    """Fixture returning a configured Traefik Proxy"""
-    proxy = create_toml_proxy()
+    """Fixture returning a configured TraefikTomlProxy"""
+    proxy = TraefikTomlProxy(
+        public_url="http://127.0.0.1:8000",
+        traefik_api_password="admin",
+        traefik_api_username="api_admin",
+    )
     await proxy.start()
     yield proxy
-    # await proxy.stop()
+    await proxy.stop()
+
+
+@pytest.fixture(params=["etcd_proxy", "toml_proxy"])
+def proxy(request):
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import os
 import shutil
 
 from jupyterhub_traefik_proxy import TraefikEtcdProxy
+from jupyterhub_traefik_proxy import TraefikTomlProxy
 from os.path import abspath, dirname, join
 
 
@@ -15,6 +16,19 @@ from os.path import abspath, dirname, join
 async def proxy():
     """Fixture returning a configured Traefik Proxy"""
     proxy = TraefikEtcdProxy(
+        public_url="http://127.0.0.1:8000",
+        traefik_api_password="admin",
+        traefik_api_username="api_admin",
+    )
+    await proxy.start()
+    yield proxy
+    await proxy.stop()
+
+
+@pytest.fixture
+async def toml_proxy():
+    """Fixture returning a configured Traefik Proxy"""
+    proxy = TraefikTomlProxy(
         public_url="http://127.0.0.1:8000",
         traefik_api_password="admin",
         traefik_api_username="api_admin",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def proxy(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session", autouse=True)
 def etcd():
     etcd_proc = subprocess.Popen("etcd", stdout=None, stderr=None)
     yield etcd_proc
@@ -52,7 +52,7 @@ def etcd():
     shutil.rmtree(os.getcwd() + "/default.etcd/")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function", autouse=True)
 def clean_etcd():
     subprocess.run(["etcdctl", "del", '""', "--from-key=true"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,30 +12,51 @@ from jupyterhub_traefik_proxy import TraefikTomlProxy
 from os.path import abspath, dirname, join
 
 
-@pytest.fixture
-async def proxy():
-    """Fixture returning a configured Traefik Proxy"""
+def create_etcd_proxy():
+    """Function returning a TraefikEtcdProxy object"""
     proxy = TraefikEtcdProxy(
         public_url="http://127.0.0.1:8000",
         traefik_api_password="admin",
         traefik_api_username="api_admin",
     )
-    await proxy.start()
-    yield proxy
-    await proxy.stop()
+    return proxy
 
 
-@pytest.fixture
-async def toml_proxy():
-    """Fixture returning a configured Traefik Proxy"""
+def create_toml_proxy():
+    """Function returning a TraefikTomlProxy object"""
     proxy = TraefikTomlProxy(
         public_url="http://127.0.0.1:8000",
         traefik_api_password="admin",
         traefik_api_username="api_admin",
     )
+    return proxy
+
+
+@pytest.fixture(params=[create_etcd_proxy, create_toml_proxy])
+async def proxy(request):
+    """Fixture returning a configured Traefik Proxy"""
+    proxy = request.param()
     await proxy.start()
     yield proxy
     await proxy.stop()
+
+
+@pytest.fixture()
+async def etcd_proxy():
+    """Fixture returning a configured Traefik Proxy"""
+    proxy = create_etcd_proxy()
+    await proxy.start()
+    yield proxy
+    # await proxy.stop()
+
+
+@pytest.fixture()
+async def toml_proxy():
+    """Fixture returning a configured Traefik Proxy"""
+    proxy = create_toml_proxy()
+    await proxy.start()
+    yield proxy
+    # await proxy.stop()
 
 
 @pytest.fixture(scope="module")
@@ -62,7 +83,7 @@ _ports = {"default_backend": 9000, "first_backend": 9090, "second_backend": 9099
 
 
 @pytest.fixture
-def launch_backends(request):
+def launch_backends():
     default_backend_port, first_backend_port, second_backend_port = (
         utils.get_backend_ports()
     )
@@ -79,13 +100,19 @@ def launch_backends(request):
         [sys.executable, dummy_server_path, str(second_backend_port)], stdout=None
     )
 
-    request.addfinalizer(default_backend.kill)
-    request.addfinalizer(first_backend.kill)
-    request.addfinalizer(second_backend.kill)
+    yield
+
+    default_backend.kill()
+    first_backend.kill()
+    second_backend.kill()
+
+    default_backend.wait()
+    first_backend.wait()
+    second_backend.wait()
 
 
 @pytest.fixture
-def default_backend(request):
+def default_backend():
     default_backend_port, _, _ = utils.get_backend_ports()
 
     dummy_server_path = abspath(join(dirname(__file__), "dummy_http_server.py"))
@@ -94,4 +121,6 @@ def default_backend(request):
         [sys.executable, dummy_server_path, str(default_backend_port)], stdout=None
     )
 
-    request.addfinalizer(default_backend.kill)
+    yield
+    default_backend.kill()
+    default_backend.wait()

--- a/tests/dummy_http_server.py
+++ b/tests/dummy_http_server.py
@@ -16,7 +16,6 @@ class DummyServer(BaseHTTPRequestHandler):
 
 def run(port=80):
     dummy_server = HTTPServer(("localhost", port), DummyServer)
-    print("Starting dummy server...")
 
     try:
         dummy_server.serve_forever()

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -112,7 +112,7 @@ def check_route_with_etcdctl(etcd_proxy, routespec, target, data, test_deletion=
 @pytest.mark.parametrize("routespec", ["/proxy/path", "host/proxy/path"])
 @pytest.mark.parametrize("target", ["http://127.0.0.1:99"])
 @pytest.mark.parametrize("data", [{"test": "test1"}, {}])
-async def test_add_route_to_etcd(etcd, clean_etcd, etcd_proxy, routespec, target, data):
+async def test_add_route_to_etcd(etcd_proxy, routespec, target, data):
     proxy = etcd_proxy
     await proxy.add_route(routespec, target, data)
     check_route_with_etcdctl(proxy, routespec, target, data)
@@ -121,9 +121,7 @@ async def test_add_route_to_etcd(etcd, clean_etcd, etcd_proxy, routespec, target
 @pytest.mark.parametrize("routespec", ["/proxy/path", "host/proxy/path"])
 @pytest.mark.parametrize("target", ["http://127.0.0.1:99"])
 @pytest.mark.parametrize("data", [{"test": "test1"}, {}])
-async def test_delete_route_from_etcd(
-    etcd, clean_etcd, etcd_proxy, routespec, target, data
-):
+async def test_delete_route_from_etcd(etcd_proxy, routespec, target, data):
     proxy = etcd_proxy
     add_route_with_etcdctl(proxy, routespec, target, data)
     await proxy.delete_route(routespec)
@@ -163,16 +161,14 @@ async def test_delete_route_from_etcd(
         ),  # Host-based routing
     ],
 )
-async def test_get_route(
-    etcd, clean_etcd, etcd_proxy, routespec, target, data, expected_output
-):
+async def test_get_route(etcd_proxy, routespec, target, data, expected_output):
     proxy = etcd_proxy
     add_route_with_etcdctl(proxy, routespec, target, data)
     route = await proxy.get_route(routespec)
     assert route == expected_output
 
 
-async def test_get_all_routes(etcd, clean_etcd, etcd_proxy):
+async def test_get_all_routes(etcd_proxy):
     proxy = etcd_proxy
     routespec = ["/proxy/path1", "/proxy/path2", "host/proxy/path"]
     target = ["http://127.0.0.1:990", "http://127.0.0.1:909", "http://127.0.0.1:999"]

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -42,13 +42,17 @@ def assert_etcdctl_del(key, expected_rv):
 def add_route_with_etcdctl(proxy, routespec, target, data):
     jupyterhub_routespec = proxy.etcd_jupyterhub_prefix + routespec
     backend_alias = traefik_utils.create_backend_alias_from_url(target)
-    backend_url_path = traefik_utils.create_backend_url_path(proxy, backend_alias)
-    backend_weight_path = traefik_utils.create_backend_weight_path(proxy, backend_alias)
+    backend_url_path = traefik_utils.create_backend_entry(
+        proxy, backend_alias, url=True
+    )
+    backend_weight_path = traefik_utils.create_backend_entry(
+        proxy, backend_alias, weight=True
+    )
     frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
-    frontend_backend_path = traefik_utils.create_frontend_backend_path(
+    frontend_backend_path = traefik_utils.create_frontend_backend_entry(
         proxy, frontend_alias
     )
-    frontend_rule_path = traefik_utils.create_frontend_rule_path(proxy, frontend_alias)
+    frontend_rule_path = traefik_utils.create_frontend_rule_entry(proxy, frontend_alias)
     if routespec.startswith("/"):
         # Path-based route, e.g. /proxy/path/
         rule = "PathPrefix:" + routespec
@@ -70,14 +74,18 @@ def add_route_with_etcdctl(proxy, routespec, target, data):
 def check_route_with_etcdctl(proxy, routespec, target, data, test_deletion=False):
     jupyterhub_routespec = proxy.etcd_jupyterhub_prefix + routespec
     backend_alias = traefik_utils.create_backend_alias_from_url(target)
-    backend_url_path = traefik_utils.create_backend_url_path(proxy, backend_alias)
+    backend_url_path = traefik_utils.create_backend_entry(
+        proxy, backend_alias, url=True
+    )
     backend_alias = traefik_utils.create_backend_alias_from_url(target)
-    backend_weight_path = traefik_utils.create_backend_weight_path(proxy, backend_alias)
+    backend_weight_path = traefik_utils.create_backend_entry(
+        proxy, backend_alias, weight=True
+    )
     frontend_alias = traefik_utils.create_frontend_alias_from_url(target)
-    frontend_backend_path = traefik_utils.create_frontend_backend_path(
+    frontend_backend_path = traefik_utils.create_frontend_backend_entry(
         proxy, frontend_alias
     )
-    frontend_rule_path = traefik_utils.create_frontend_rule_path(proxy, frontend_alias)
+    frontend_rule_path = traefik_utils.create_frontend_rule_entry(proxy, frontend_alias)
     if routespec.startswith("/"):
         # Path-based route, e.g. /proxy/path/
         rule = "PathPrefix:" + routespec

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -42,7 +42,7 @@ def assert_etcdctl_del(key, expected_rv):
 def add_route_with_etcdctl(etcd_proxy, routespec, target, data):
     proxy = etcd_proxy
     jupyterhub_routespec = proxy.etcd_jupyterhub_prefix + routespec
-    route_keys = traefik_utils.generate_route_keys(proxy, target, routespec)
+    route_keys = traefik_utils.generate_route_keys(proxy, routespec, routespec)
     rule = traefik_utils.generate_rule(routespec)
     expected_rv = "OK"
 
@@ -61,7 +61,7 @@ def add_route_with_etcdctl(etcd_proxy, routespec, target, data):
 def check_route_with_etcdctl(etcd_proxy, routespec, target, data, test_deletion=False):
     proxy = etcd_proxy
     jupyterhub_routespec = proxy.etcd_jupyterhub_prefix + routespec
-    route_keys = traefik_utils.generate_route_keys(proxy, target, routespec)
+    route_keys = traefik_utils.generate_route_keys(proxy, routespec, routespec)
     rule = traefik_utils.generate_rule(routespec)
 
     if test_deletion:
@@ -162,7 +162,6 @@ async def test_get_all_routes(etcd_proxy):
     routespec = ["/proxy/path1", "/proxy/path2", "host/proxy/path"]
     target = ["http://127.0.0.1:990", "http://127.0.0.1:909", "http://127.0.0.1:999"]
     data = [{"test": "test1"}, {}, {"test": "test2"}]
-    dict_keys = ["routespec", "target", "data"]
 
     expected_output = {
         routespec[0]: {

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -14,17 +14,11 @@ pytestmark = pytest.mark.asyncio
 
 
 async def wait_for_services(proxy, target):
-    traefik_port = urlparse(proxy.public_url).port
-    traefik_ip = urlparse(proxy.public_url).hostname
-    backend_port = urlparse(target).port
-    backend_ip = urlparse(target).hostname
-
     # Wait until traefik and the backend are ready
     await exponential_backoff(
         utils.check_services_ready,
         "Service not reacheable",
-        ips=[traefik_ip, backend_ip],
-        ports=[traefik_port, backend_port],
+        urls=[proxy.public_url, target],
     )
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -16,9 +16,7 @@ pytestmark = pytest.mark.asyncio
 async def wait_for_services(urls):
     # Wait until traefik and the backend are ready
     await exponential_backoff(
-        utils.check_services_ready,
-        "Service not reacheable",
-        urls=urls,
+        utils.check_services_ready, "Service not reacheable", urls=urls
     )
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -11,37 +11,7 @@ from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 pytestmark = pytest.mark.asyncio
 
 
-# async def test_etcd_routing_toml(toml_proxy, launch_backends):
-#     proxy = toml_proxy
-#     routespec = ["/", "/user/first", "/user/second"]
-#     target = ["http://127.0.0.1:9000", "http://127.0.0.1:9090", "http://127.0.0.1:9099"]
-#     data = [{}, {}, {}]
-
-#     routes_no = len(target)
-#     traefik_port = urlparse(proxy.public_url).port
-
-#     # Check if traefik process is reacheable
-#     await exponential_backoff(
-#         utils.check_host_up, "Traefik not reacheable", ip="localhost", port=traefik_port
-#     )
-
-#     # Check if backends are reacheable
-#     await exponential_backoff(utils.check_backends_up, "Backends not reacheable")
-
-#     # Add testing routes
-#     await proxy.add_route(routespec[0], target[0], data[0])
-#     await proxy.add_route(routespec[1], target[1], data[1])
-#     await proxy.add_route(routespec[2], target[2], data[2])
-
-#     if proxy.public_url.endswith("/"):
-#         req_url = proxy.public_url[:-1]
-#     else:
-#         req_url = proxy.public_url
-
-#     await utils.check_routing(req_url)
-
-
-async def test_etcd_routing(etcd, clean_etcd, proxy, launch_backends):
+async def test_routing(etcd, clean_etcd, proxy, launch_backends):
     routespec = ["/", "/user/first", "/user/second"]
     target = ["http://127.0.0.1:9000", "http://127.0.0.1:9090", "http://127.0.0.1:9099"]
     data = [{}, {}, {}]
@@ -122,12 +92,10 @@ async def test_traefik_api_without_auth(etcd, clean_etcd, proxy, default_backend
     try:
         resp = await AsyncHTTPClient().fetch(proxy.traefik_api_url + "/dashboard")
         rc = resp.code
-        print(rc)
     except ConnectionRefusedError:
         rc = None
     except Exception as e:
         rc = e.response.code
-        print(rc)
     finally:
         assert rc in {401, 403}
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -97,7 +97,7 @@ async def test_traefik_api_without_auth(etcd, clean_etcd, proxy, default_backend
     except Exception as e:
         rc = e.response.code
     finally:
-        return rc == 401 or rc == 403
+        assert rc in {401, 403}
 
 
 async def test_traefik_api_wit_auth(etcd, clean_etcd, proxy, default_backend):
@@ -107,6 +107,9 @@ async def test_traefik_api_wit_auth(etcd, clean_etcd, proxy, default_backend):
         utils.check_host_up, "Traefik not reacheable", ip="localhost", port=traefik_port
     )
 
+    print(proxy.traefik_api_username)
+    print(proxy.traefik_api_password)
+
     try:
         resp = await AsyncHTTPClient().fetch(
             proxy.traefik_api_url + "/dashboard",
@@ -115,9 +118,10 @@ async def test_traefik_api_wit_auth(etcd, clean_etcd, proxy, default_backend):
         )
 
         rc = resp.code
+        print(rc)
     except ConnectionRefusedError:
         rc = None
     except Exception as e:
         rc = e.response.code
     finally:
-        return rc == 200
+        assert rc == 200

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -64,7 +64,7 @@ async def wait_for_services(proxy, target):
     ],
 )
 async def test_add_get_delete(
-    etcd, clean_etcd, proxy, launch_backend, routespec, target, data, expected_output
+    proxy, launch_backend, routespec, target, data, expected_output
 ):
     backend_port = urlparse(target).port
     launch_backend(backend_port)
@@ -106,7 +106,7 @@ async def test_add_get_delete(
     await exponential_backoff(_wait_for_deletion, "Route still exists")
 
 
-async def test_host_origin_headers(etcd, clean_etcd, proxy, launch_backend):
+async def test_host_origin_headers(proxy, launch_backend):
     routespec = "/user/username"
     target = "http://127.0.0.1:9000"
     data = {}

--- a/tests/test_traefik_api_auth.py
+++ b/tests/test_traefik_api_auth.py
@@ -1,0 +1,42 @@
+"""Tests for the authentication to the traefik proxy api (dashboard)"""
+import pytest
+import utils
+
+from urllib.parse import urlparse
+from jupyterhub.utils import exponential_backoff
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+# Mark all tests in this file as asyncio
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize(
+    "username, password, expected_rc",
+    [("api_admin", "admin", 200), ("api_admin", "1234", 401), ("", "", 401)],
+)
+async def test_traefik_api_auth(
+    etcd, clean_etcd, proxy, username, password, expected_rc
+):
+    # proxy = etcd_proxy
+    traefik_port = urlparse(proxy.public_url).port
+
+    await exponential_backoff(
+        utils.check_host_up, "Traefik not reacheable", ip="localhost", port=traefik_port
+    )
+
+    try:
+        if not username and not password:
+            resp = await AsyncHTTPClient().fetch(proxy.traefik_api_url + "/dashboard")
+        else:
+            resp = await AsyncHTTPClient().fetch(
+                proxy.traefik_api_url + "/dashboard/",
+                auth_username=username,
+                auth_password=password,
+            )
+        rc = resp.code
+    except ConnectionRefusedError:
+        rc = None
+    except Exception as e:
+        rc = e.response.code
+    finally:
+        assert rc == expected_rc

--- a/tests/test_traefik_api_auth.py
+++ b/tests/test_traefik_api_auth.py
@@ -14,10 +14,7 @@ pytestmark = pytest.mark.asyncio
     "username, password, expected_rc",
     [("api_admin", "admin", 200), ("api_admin", "1234", 401), ("", "", 401)],
 )
-async def test_traefik_api_auth(
-    etcd, clean_etcd, proxy, username, password, expected_rc
-):
-    # proxy = etcd_proxy
+async def test_traefik_api_auth(proxy, username, password, expected_rc):
     traefik_port = urlparse(proxy.public_url).port
 
     await exponential_backoff(

--- a/tests/test_traefik_utils.py
+++ b/tests/test_traefik_utils.py
@@ -1,0 +1,39 @@
+import pytest
+import json
+import os
+from jupyterhub_traefik_proxy import traefik_utils
+
+# Mark all tests in this file as asyncio
+def test_roundtrip_routes():
+    pytestmark = pytest.mark.asyncio
+    routes = {
+        "backends": {
+            "backend1": {
+                "servers": {
+                    "server1": {
+                        "url": "http://127.0.0.1:9009",
+                        "weight": 1
+                        }
+                    }
+                }
+            },
+        "frontends": {
+            "frontend1": {
+                "backend": "backend1",
+                "passHostHeader": True,
+                "routes": {
+                    "test": {
+                        "rule": "Host:host;PathPrefix:/proxy/path",
+                        "data": json.dumps({"test": "test1"})
+                    }
+                }
+            }
+        }
+    }
+
+    file = "test_roudtrip.toml"
+    open(file, "a").close()
+    traefik_utils.persist_routes(file, routes)
+    reloaded = traefik_utils.load_routes(file)
+    os.remove(file)
+    assert reloaded == routes

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import json
 
 from jupyterhub.utils import exponential_backoff
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPClientError
+from urllib.parse import urlparse
 
 _ports = {"default_backend": 9000, "first_backend": 9090, "second_backend": 9099}
 
@@ -50,9 +51,11 @@ async def get_responding_backend_port(traefik_url, path):
         raise e
 
 
-async def check_services_ready(ips, ports):
+async def check_services_ready(urls):
     ready = True
-    for ip, port in zip(ips, ports):
+    for url in urls:
+        ip = urlparse(url).hostname
+        port = urlparse(url).port
         status = await check_host_up(ip=ip, port=port)
         ready = ready and status
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 import socket
 import json
-from tornado.httpclient import AsyncHTTPClient
+
+from jupyterhub.utils import exponential_backoff
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest, HTTPClientError
 
 _ports = {"default_backend": 9000, "first_backend": 9090, "second_backend": 9099}
 
@@ -29,51 +31,29 @@ async def check_host_up(ip, port):
     return is_open(ip, port)
 
 
-async def traefik_routes_to_correct_backend(traefik_url, path, expected_port):
+async def get_responding_backend_port(traefik_url, path):
     """ Check if traefik followed the configuration and routed the
     request to the right backend """
-    resp = await AsyncHTTPClient().fetch(traefik_url + path)
-    data = json.loads(resp.body)
-    assert data == expected_port
+    if not path.startswith("/"):
+        req = HTTPRequest(
+            traefik_url + "".join("/" + path.split("/", 1)[1]),
+            method="GET",
+            headers={"Host": path.split("/")[0]},
+        )
+    else:
+        req = traefik_url + path
+
+    try:
+        resp = await AsyncHTTPClient().fetch(req)
+        return json.loads(resp.body)
+    except HTTPClientError as e:
+        raise e
 
 
-def get_backend_ports():
-    default_backend_port = get_port("default_backend")
-    first_backend_port = get_port("first_backend")
-    second_backend_port = get_port("second_backend")
-    return default_backend_port, first_backend_port, second_backend_port
+async def check_services_ready(ips, ports):
+    ready = True
+    for ip, port in zip(ips, ports):
+        status = await check_host_up(ip=ip, port=port)
+        ready = ready and status
 
-
-async def check_backends_up():
-    """ Verify if the backends started listening on their designated
-    ports """
-    default_backend_port, first_backend_port, second_backend_port = get_backend_ports()
-    default_up = await check_host_up("localhost", default_backend_port) == True
-    first_up = await check_host_up("localhost", first_backend_port) == True
-    second_up = await check_host_up("localhost", second_backend_port) == True
-
-    return default_up and first_up and second_up
-
-
-async def check_routing(traefik_url):
-    default_backend_port, first_backend_port, second_backend_port = get_backend_ports()
-    """ Send GET requests for resources on different paths and check
-    they are routed based on their path-prefixes """
-    await traefik_routes_to_correct_backend(
-        traefik_url, "/otherthings", default_backend_port
-    )
-    await traefik_routes_to_correct_backend(
-        traefik_url, "/user/somebody", default_backend_port
-    )
-    await traefik_routes_to_correct_backend(
-        traefik_url, "/user/first", first_backend_port
-    )
-    await traefik_routes_to_correct_backend(
-        traefik_url, "/user/second", second_backend_port
-    )
-    await traefik_routes_to_correct_backend(
-        traefik_url, "/user/first/otherthings", first_backend_port
-    )
-    await traefik_routes_to_correct_backend(
-        traefik_url, "/user/second/otherthings", second_backend_port
-    )
+    return ready

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,7 @@ async def check_host_up(ip, port):
 async def traefik_routes_to_correct_backend(traefik_url, path, expected_port):
     """ Check if traefik followed the configuration and routed the
     request to the right backend """
+    print(traefik_url + path)
     resp = await AsyncHTTPClient().fetch(traefik_url + path)
     data = json.loads(resp.body)
     assert data == expected_port
@@ -60,20 +61,20 @@ async def check_routing(traefik_url):
     """ Send GET requests for resources on different paths and check
     they are routed based on their path-prefixes """
     await traefik_routes_to_correct_backend(
-        traefik_url, "/otherthings", default_backend_port
+        traefik_url, "/otherthings/", default_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/somebody", default_backend_port
+        traefik_url, "/user/somebody/", default_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/first", first_backend_port
+        traefik_url, "/user/first/", first_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/second", second_backend_port
+        traefik_url, "/user/second/", second_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/first/otherthings", first_backend_port
+        traefik_url, "/user/first/otherthings/", first_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/second/otherthings", second_backend_port
+        traefik_url, "/user/second/otherthings/", second_backend_port
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,7 +32,6 @@ async def check_host_up(ip, port):
 async def traefik_routes_to_correct_backend(traefik_url, path, expected_port):
     """ Check if traefik followed the configuration and routed the
     request to the right backend """
-    print(traefik_url + path)
     resp = await AsyncHTTPClient().fetch(traefik_url + path)
     data = json.loads(resp.body)
     assert data == expected_port

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,20 +60,20 @@ async def check_routing(traefik_url):
     """ Send GET requests for resources on different paths and check
     they are routed based on their path-prefixes """
     await traefik_routes_to_correct_backend(
-        traefik_url, "/otherthings/", default_backend_port
+        traefik_url, "/otherthings", default_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/somebody/", default_backend_port
+        traefik_url, "/user/somebody", default_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/first/", first_backend_port
+        traefik_url, "/user/first", first_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/second/", second_backend_port
+        traefik_url, "/user/second", second_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/first/otherthings/", first_backend_port
+        traefik_url, "/user/first/otherthings", first_backend_port
     )
     await traefik_routes_to_correct_backend(
-        traefik_url, "/user/second/otherthings/", second_backend_port
+        traefik_url, "/user/second/otherthings", second_backend_port
     )


### PR DESCRIPTION
closes https://github.com/jupyterhub/traefik-proxy/issues/21

The data passed in when adding a route is only stored in memory. I couldn't add it in the toml file because traefik doesn't know how to parse it. @minrk , do you think we should we also store it in a file (other than the two tomls)? 

I also tried to move some of the common api to the base class TraefikProxy and made `test_proxy.py` work for both proxy implementations.