### PR TITLE
more logging / error handling

### DIFF
--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -88,7 +88,7 @@ class TraefikTomlProxy(TraefikProxy):
                 os.remove(self.toml_static_config_file)
             os.remove(self.toml_dynamic_config_file)
         except:
-            self.log.error("Failed to remove traefik's configuration files \n")
+            self.log.error("Failed to remove traefik's configuration files")
             raise
 
     def _get_route_unsafe(self, routespec):


### PR DESCRIPTION
to help with debugging when something's wrong (usually misconfiguration)

- warn if traefik api username or password is empty
- debug-logging to stages
- log errors in api requests
- consolidate api request implementation into a method

@GeorgianaElena these changes helped me figure out the last bit of https://github.com/jupyterhub/the-littlest-jupyterhub/pull/266 because each attempt to access the traefik api was failing with 401:

    tornado.httpclient.HTTPClientError: HTTP 401: Unauthorized

ultimately, the issue was that the `generate_traefik_api_credentials` wasn't called during the loading process in jupyterhub_config.py, so `traefik_api_password` was an empty string. I also added an explicit warning when this happens, to make it easier to catch.