### PR TITLE
close temporary file before renaming it

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,10 @@ Changes in jupyterhub-traefik-proxy
 Unreleased
 ----------
 
+0.1.2
+-----
+
+- Fix possible race in atomic_writing with TraefikTomlProxy
 
 0.1.1
 -----


### PR DESCRIPTION
in atomic_writing

may fix possible partial-file events that fsync was supposed to ensure before. Close is a more robust barrier that ensures the file is fully written.