### PR TITLE
Explicitly close consul client session

### DIFF
--- a/jupyterhub_traefik_proxy/consul.py
+++ b/jupyterhub_traefik_proxy/consul.py
@@ -224,3 +224,7 @@ class TraefikConsulProxy(TKvProxy):
         )
 
         return routes["Results"]
+
+    async def stop(self):
+        await super().stop()
+        await self.kv_client.http._session.close()

--- a/jupyterhub_traefik_proxy/kv_proxy.py
+++ b/jupyterhub_traefik_proxy/kv_proxy.py
@@ -50,11 +50,13 @@ class TKvProxy(TraefikProxy):
     kv_url = Unicode(config=True, help="""The URL of the key value store server""")
 
     kv_traefik_prefix = Unicode(
-        config=True, help="""The key value store key prefix for traefik static configuration"""
+        config=True,
+        help="""The key value store key prefix for traefik static configuration""",
     )
 
     kv_jupyterhub_prefix = Unicode(
-        config=True, help="""The key value store key prefix for traefik dynamic configuration"""
+        config=True,
+        help="""The key value store key prefix for traefik dynamic configuration""",
     )
 
     def _define_kv_specific_static_config(self):

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -46,9 +46,7 @@ class TraefikProxy(Proxy):
         help="""traefik authenticated api endpoint url""",
     )
 
-    traefik_log_level = Unicode(
-        "ERROR", config=True, help="""traefik's log level"""
-    )
+    traefik_log_level = Unicode("ERROR", config=True, help="""traefik's log level""")
 
     traefik_api_password = Unicode(
         config=True, help="""The password for traefik api login"""

--- a/performance/check_perf.py
+++ b/performance/check_perf.py
@@ -106,9 +106,7 @@ async def run_methods_concurrent(method, proxy, routes_number, stdout_print):
 async def run_methods_sequentially(method, proxy, routes_number, stdout_print):
     res = {}
     with perf_utils.measure_time(
-        f"Running {method.__name__} for {routes_number} total routes, took",
-        True,
-        {},
+        f"Running {method.__name__} for {routes_number} total routes, took", True, {}
     ):
         for route_idx in range(routes_number):
             _, t = await method(proxy, route_idx, stdout_print)
@@ -258,7 +256,9 @@ def main():
                 mode = "concurrent"
             else:
                 mode = "sequentially"
-            print(f"Starting {metric} {mode} measurement number {i} for {proxy_class} ...\n")
+            print(
+                f"Starting {metric} {mode} measurement number {i} for {proxy_class} ...\n"
+            )
             results[i] = loop.run_until_complete(
                 measure_methods_performance(
                     concurrent, proxy_class, routes_number, csv_filename is None


### PR DESCRIPTION
The consul client in TraefikConsulProxy (*python-consul*) uses aiohttp and according to [its changelog](https://docs.aiohttp.org/en/stable/changes.html#id726), since 0.21.0 *ClientSession.close and Connector.close are coroutines now*.

From my understanding, *python-consul* didn't yet adapt to this change ([1](https://github.com/cablehead/python-consul/blob/b7870b73b66c49e9e12647a14d5fdd6670451733/consul/aio.py#L34), [2](https://github.com/cablehead/python-consul/blob/b7870b73b66c49e9e12647a14d5fdd6670451733/consul/aio.py#L71) and [3](https://github.com/cablehead/python-consul/blob/b7870b73b66c49e9e12647a14d5fdd6670451733/consul/aio.py#L57)) and I believe this is where the warnings come from. 

As a workaround, we can close the session in ```proxy.stop```, but this fix won't solve the warnings when the proxy is externally managed.
 
closes https://github.com/jupyterhub/traefik-proxy/issues/63