### PR TITLE
CONTRIBUTING: use long option in "pip install -e"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This package requires Python >= 3.5.
 
 As a Python package, you can set up a development environment by cloning this repo and running:
 
-    python3 -m pip install -e .
+    python3 -m pip install --editable .
 
 from the repo directory.
 


### PR DESCRIPTION
Replace pip install -e with its equivalent long option pip install --editable.

This makes the documentation more explicit for people not familiar with pip command line.