### PR TITLE
Handle ssl

### DIFF
--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -209,11 +209,24 @@ class TraefikProxy(Proxy):
         self._generate_htpassword()
 
         self.static_config = {}
-        self.static_config["defaultentrypoints"] = ["http"]
         self.static_config["debug"] = True
         self.static_config["logLevel"] = self.traefik_log_level
         entryPoints = {}
-        entryPoints["http"] = {"address": ":" + str(urlparse(self.public_url).port)}
+
+        if self.ssl_cert and self.ssl_key:
+            self.static_config["defaultentrypoints"] = ["https"]
+            entryPoints["https"] = {
+                "address": ":" + str(urlparse(self.public_url).port),
+                "tls": {
+                    "certificates": [
+                        {"certFile": self.ssl_cert, "keyFile": self.ssl_key}
+                    ]
+                },
+            }
+        else:
+            self.static_config["defaultentrypoints"] = ["http"]
+            entryPoints["http"] = {"address": ":" + str(urlparse(self.public_url).port)}
+
         auth = {
             "basic": {
                 "users": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jupyterhub>=0.9
 etcd3
-aiohttp
+aiohttp==3.6.2
 python-consul
 passlib
 toml


### PR DESCRIPTION
Closes https://github.com/jupyterhub/traefik-proxy/issues/83. 

The PR also pinns *aiohttp* version to the latest release because the pre-release included a change that breaks the consul client we're using.