### PR TITLE
 Travis deploy tags to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 sudo: false
 cache:
   - pip
-python:
-  - 3.6
 env:
   global:
     - ASYNC_TEST_TIMEOUT=15
@@ -26,12 +24,21 @@ after_success:
   - codecov
 
 # auto-deploy releases on tags
-deploy:
-  provider: pypi
-  distributions: sdist bdist_wheel
-  user: jupyterhub-bot
-  password:
-    secure: mZbQVF80AO+cxJM/0qbeFoAcHSBE3YSeT4igUXlKypRVEc0qNskJbh6Ofh5qIHb4dO/LF7Si3Bms1cP3Wai7wPFAglGPV/CQ3TQjrwjWy1FYwyAvduSiKZ7xsHoSvVakqfzl8R/XSmBbajbECts+7NuJuyJGAvWldeHlWo7UXt+wiKFCK8jGcXcqCcf8F8kVkF7gfx+Z/sO3JMintMclz+N3GoUiNYnmZ3fI3PEoFeDETGy9mzlM8eQi6LnZ16rod53KKA1q3EKziNvqVgYObgD95NfH/gtgZ+rDhEIS0kPMUUu5ihfofvY/I2tV3IX/Pbih2ssHDRolthVcbPP1+L1WdCPos7IpEHKDYZuTwMizuaPaGes2YHREMCN3AtncT456X4gtH7KuWG3gAXOrmTLDp+ShaevoJCF0Qk2E0WzVngqV//stFOhwZaxV1uRb4xujTI0Ak35yKnfuiLbrOyoZ+8eiwOwhE2C0l3BKNy+xLpBMQZVoX87WTPrQzNOv6bV5ZX9Mp+pJTOnUFJOrwvLHCm3hZtWMcijAVNuR3Wi0zsJVaqCtB7/qqUtWw1PUpwyVnA9DpgGOxXo4+tVDy75izq0GTYivqpFq9EyXzE2UyxDjgRK+I3OAEUiSJ1tIGw/T2306iVf2EfpMVjWQdX4Wnz+b123bTIE7haoiUxc=
-  on:
-    tags: true
-    repo: jupyterhub/traefik-proxy
+jobs:
+  fast_finish: true
+  include:
+    - python: 3.6
+    - python: 3.7
+    # Only deploy if all test jobs passed
+    - stage: deploy
+      python: 3.7
+      if: tag IS present
+      deploy:
+        provider: pypi
+        user: jupyterhub-bot
+        # password: see secret PYPI_PASSWORD variable
+        distributions: sdist bdist_wheel
+        on:
+          # Without this we get the note about:
+          # Skipping a deployment with the pypi provider because this branch is not permitted: <tag>
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
-sudo: false
 cache:
   - pip
 env:
   global:
-    - ASYNC_TEST_TIMEOUT=15
     - ETCDCTL_API=3
 
 # installing dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       if: tag IS present
       deploy:
         provider: pypi
-        user: jupyterhub-bot
+        user: __token__
         # password: see secret PYPI_PASSWORD variable
         distributions: sdist bdist_wheel
         on:

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ API](https://jupyterhub.readthedocs.io/en/stable/reference/proxy.html),
 depending on how traefik store its routing configuration.
 
 For **smaller**, single-node deployments:
-	* TraefikTomlProxy
-For **distributed** setups
-	* TraefikEtcdProxy
-	* TraefikConsulProxy
 
+* TraefikTomlProxy
+
+For **distributed** setups:
+
+* TraefikEtcdProxy
+* TraefikConsulProxy
 
 ## Installation
 The [documentation](https://jupyterhub-traefik-proxy.readthedocs.io) contains a

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![TravisCI (.org) build status](https://img.shields.io/travis/jupyterhub/traefik-proxy/master?logo=travis)](https://travis-ci.org/jupyterhub/traefik-proxy)
 [![CircleCI build status](https://img.shields.io/circleci/build/github/jupyterhub/jupyterhub?logo=circleci)](https://circleci.com/gh/jupyterhub/jupyterhub)
 [![Latest PyPI version](https://img.shields.io/pypi/v/jupyterhub-traefik-proxy?logo=pypi)](https://pypi.python.org/pypi/jupyterhub-traefik-proxy)
-[![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/jupyterhub/issues)
+[![GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/traefik-proxy/issues)
 [![Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)
 [![Gitter](https://img.shields.io/badge/social_chat-gitter-blue?logo=gitter)](https://gitter.im/jupyterhub/jupyterhub)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,71 @@
+# How to make a release
+
+`traefik-proxy` is a package [available on
+PyPI](https://pypi.org/project/jupyterhub-traefik-proxy/).
+The PyPI release is done automatically by TravisCI when a tag
+is pushed.
+
+For you to follow along according to these instructions, you need
+to have push rights to the [traefik-proxy GitHub
+repository](https://github.com/jupyterhub/traefik-proxy).
+
+## Steps to make a release
+
+1. Checkout master and make sure it is up to date.
+
+   ```shell
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout master
+   git fetch $ORIGIN master
+   git reset --hard $ORIGIN/master
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Update [changelog.rst](docs/source/changelog.rst) and add it to
+   the working tree.
+   
+   ```shell
+   git add traefik-proxy/docs/source/changelog.rst
+   ```
+
+   Tip: Identifying the changes can be made easier with the help of the
+   [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
+   utility.
+
+1. Set a shell variable to be the new version you want to release.  
+   
+   ```shell
+   VERSION=...  # e.g. 1.2.3
+   git commit -m "release $VERSION"
+   ```
+
+   Tip: You can get the current project version with:
+   
+   ```shell
+   git describe --abbrev=0
+   ```
+
+1. Push your commit to master.
+
+   ```shell
+   # first push commits without a tags to ensure the
+   # commits comes through, because a tag can otherwise
+   # be pushed all alone without company of rejected
+   # commits, and we want have our tagged release coupled
+   # with a specific commit in master
+   git push $ORIGIN master
+   ```
+
+1. Create a git tag for the pushed release commit and push it.
+
+   ```shell
+   git tag -a $VERSION -m $VERSION HEAD~1
+
+   # then verify you tagged the right commit
+   git log
+
+   # then push it
+   git push $ORIGIN refs/tags/$VERSION
+   ```
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,7 +33,8 @@ repository](https://github.com/jupyterhub/traefik-proxy).
    [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
    utility.
 
-1. Set a shell variable to be the new version you want to release.  
+1. Set a shell variable to be the new version you want to release.
+   The actual project version will be set from git automatically by versioneer.
    
    ```shell
    VERSION=...  # e.g. 1.2.3
@@ -57,12 +58,12 @@ repository](https://github.com/jupyterhub/traefik-proxy).
 1. Create a git tag for the pushed release commit and push it.
 
    ```shell
-   git tag -a $VERSION -m $VERSION HEAD~1
+   git tag -a $VERSION -m "release $VERSION"
 
    # then verify you tagged the right commit
    git log
 
    # then push it
-   git push $ORIGIN refs/tags/$VERSION
+   git push --follow-tags
    ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,12 +40,9 @@ repository](https://github.com/jupyterhub/traefik-proxy).
    git commit -m "release $VERSION"
    ```
 
-   Tip: You can get the current project version with:
+   Tip: You can get the current project version by checking the [latest
+   tag on GitHub](https://github.com/jupyterhub/traefik-proxy/tags).
    
-   ```shell
-   git describe --abbrev=0
-   ```
-
 1. Push your commit to master.
 
    ```shell

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,9 @@ repository](https://github.com/jupyterhub/traefik-proxy).
    utility.
 
 1. Set a shell variable to be the new version you want to release.
-   The actual project version will be set from git automatically by versioneer.
+   The actual project version will be detected automatically by versioneer
+   from git tags inspection. The versioneer script will be run by setup.py
+   when packaging is occurring.
    
    ```shell
    VERSION=...  # e.g. 1.2.3
@@ -64,6 +66,6 @@ repository](https://github.com/jupyterhub/traefik-proxy).
    git log
 
    # then push it
-   git push --follow-tags
+   git push $ORIGIN --follow-tags
    ```
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,29 +3,123 @@
 Changes in jupyterhub-traefik-proxy
 ===================================
 
-Unreleased
-----------
+For detailed changes from the prior release, click on the version number
+and its link will bring up a GitHub listing of changes. Use `git log` on
+the command line for details.
 
-0.1.3
------
 
-- Load initial routing table from disk in TraefikTomlProxy
-  when resuming from a previous session.
+`[Unreleased]`_
+---------------
 
-0.1.2
------
+-  Update README `#87`_
+   (`@consideRatio <https://github.com/consideRatio>`_)
+-  Handle ssl `#84`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  CONTRIBUTING: use long option in “pip install -e” `#82`_
+   (`@muxator <https://github.com/muxator>`_)
+-  Change traefik default version `#81`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Add info about TraefikConsulProxy in readme `#80`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+
+.. _#87: https://github.com/jupyterhub/traefik-proxy/pull/87
+.. _#84: https://github.com/jupyterhub/traefik-proxy/pull/84
+.. _#82: https://github.com/jupyterhub/traefik-proxy/pull/82
+.. _#81: https://github.com/jupyterhub/traefik-proxy/pull/81
+.. _#80: https://github.com/jupyterhub/traefik-proxy/pull/80
+
+`[0.1.4]`_ - 2019-09-20
+-----------------------
+
+-  Add info about TraefikConsulProxy in readme `#80`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Stop assuming kv_traefik_prefix ends with a slash `#79`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Log info about what dynamic config file it’s used by the Hub `#77`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Install script `#76`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Set defaults for traefik api username and password `#75`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Allow etcd and consul client ssl settings `#70`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Fix format in install script warnings `#69`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Create test coverage report `#65`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Explicitly close consul client session `#64`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Throughput results updated `#62`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  Make trefik’s log level configurable `#61`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  TraefikConsulProxy `#57`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+-  WIP Common proxy profiling suite `#54`_
+   `(@GeorgianaElena) <https://github.com/GeorgianaElena>`_
+
+.. _#80: https://github.com/jupyterhub/traefik-proxy/pull/80
+.. _#79: https://github.com/jupyterhub/traefik-proxy/pull/79
+.. _#77: https://github.com/jupyterhub/traefik-proxy/pull/77
+.. _#76: https://github.com/jupyterhub/traefik-proxy/pull/76
+.. _#75: https://github.com/jupyterhub/traefik-proxy/pull/75
+.. _#70: https://github.com/jupyterhub/traefik-proxy/pull/70
+.. _#69: https://github.com/jupyterhub/traefik-proxy/pull/69
+.. _#65: https://github.com/jupyterhub/traefik-proxy/pull/65
+.. _#64: https://github.com/jupyterhub/traefik-proxy/pull/64
+.. _#62: https://github.com/jupyterhub/traefik-proxy/pull/62
+.. _#61: https://github.com/jupyterhub/traefik-proxy/pull/61
+.. _#57: https://github.com/jupyterhub/traefik-proxy/pull/57
+.. _#54: https://github.com/jupyterhub/traefik-proxy/pull/54
+
+`[0.1.3]`_ - 2019-02-26
+-----------------------
+
+-  Try to load routes from file if cache is empty `#52`_
+   (`@GeorgianaElena <https://github.com/GeorgianaElena>`_)
+-  close temporary file before renaming it `#51`_
+   (`@minrk <https://github.com/minrk>`_)
+
+.. _#52: https://github.com/jupyterhub/traefik-proxy/pull/52
+.. _#51: https://github.com/jupyterhub/traefik-proxy/pull/51
+
+
+`[0.1.2]`_ - 2019-02-22
+-----------------------
 
 - Fix possible race in atomic_writing with TraefikTomlProxy
 
-0.1.1
------
+`[0.1.1]`_ - 2019-02-22
+-----------------------
 
-- make proxytest reusable with any Proxy implementation
-- improve documentation
-- improve logging and error handling
-- make check_route_timeout configurable
+-  more logging / error handling `#49`_
+   (`@minrk <https://github.com/minrk>`_)
+-  make check_route_timeout configurable `#48`_
+   (`@minrk <https://github.com/minrk>`_)
+-  Update documentation and readme `#47`_
+   (`@GeorgianaElena <https://github.com/GeorgianaElena>`_)
+-  Define only the proxy fixture in test_proxy `#46`_
+   (`@GeorgianaElena <https://github.com/GeorgianaElena>`_)
+-  add mocks so that test_check_routes needs only proxy fixture `#44`_
+   (`@minrk <https://github.com/minrk>`_)
+-  Etcd with credentials `#43`_
+   (`@GeorgianaElena <https://github.com/GeorgianaElena>`_)
+
+.. _#49: https://github.com/jupyterhub/traefik-proxy/pull/49
+.. _#48: https://github.com/jupyterhub/traefik-proxy/pull/48
+.. _#47: https://github.com/jupyterhub/traefik-proxy/pull/47
+.. _#46: https://github.com/jupyterhub/traefik-proxy/pull/46
+.. _#44: https://github.com/jupyterhub/traefik-proxy/pull/44
+.. _#43: https://github.com/jupyterhub/traefik-proxy/pull/43
+
 
 0.1.0
 -----
 
 First release!
+
+.. _[0.1.4]: https://github.com/jupyterhub/traefik-proxy/compare/0.1.3...0.1.4
+.. _[0.1.3]: https://github.com/jupyterhub/traefik-proxy/compare/0.1.2...0.1.3
+.. _[0.1.2]: https://github.com/jupyterhub/traefik-proxy/compare/0.1.1...0.1.2
+.. _[0.1.1]: https://github.com/jupyterhub/traefik-proxy/compare/0.1.0...0.1.1
+.. _[Unreleased]: https://github.com/jupyterhub/traefik-proxy/compare/0.1.4...2e96af5861f717a136ea76919dfab585643642fa

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -75,6 +75,11 @@ the command line for details.
 `[0.1.3]`_ - 2019-02-26
 -----------------------
 
+-  Load initial routing table from disk in TraefikTomlProxy
+   when resuming from a previous session.
+
+**Details:**
+
 -  Try to load routes from file if cache is empty `#52`_
    (`@GeorgianaElena <https://github.com/GeorgianaElena>`_)
 -  close temporary file before renaming it `#51`_
@@ -91,6 +96,13 @@ the command line for details.
 
 `[0.1.1]`_ - 2019-02-22
 -----------------------
+
+- make proxytest reusable with any Proxy implementation
+- improve documentation
+- improve logging and error handling
+- make check_route_timeout configurable
+
+**Details:**
 
 -  more logging / error handling `#49`_
    (`@minrk <https://github.com/minrk>`_)


### PR DESCRIPTION
This copies the release steps from other JupyterHub repos :sparkles:

The only difference is that traefik-proxy uses versioneer that takes care of the project version and some steps are missing.

(@consideRatio I never worked with versioneer before, but from what I've read it seems that _version_ is updated by it and we don't have to do anything. What do you think?)