### PR TITLE
Update etcd.py

### DIFF
--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -147,7 +147,7 @@ class TraefikEtcdProxy(TKvProxy):
     async def _kv_atomic_delete_route_parts(self, jupyterhub_routespec, route_keys):
         value = await maybe_future(self._etcd_get(jupyterhub_routespec))
         if value is None:
-            self.log.warning("Route %s doesn't exist. Nothing to delete", routespec)
+            self.log.warning("Route %s doesn't exist. Nothing to delete", jupyterhub_routespec)
             return
 
         target = value.decode()


### PR DESCRIPTION
fix NameError: name 'routespec' is not defined in _kv_atomic_delete_route_parts

Closes https://github.com/jupyterhub/traefik-proxy/issues/101