### PR TITLE
fix TypeError: 'NoneType' object is not iterable, in  delete_route when route doesn't exist

### DIFF
--- a/jupyterhub_traefik_proxy/consul.py
+++ b/jupyterhub_traefik_proxy/consul.py
@@ -167,8 +167,8 @@ class TraefikConsulProxy(TKvProxy):
 
         index, v = await self.kv_client.kv.get(escaped_jupyterhub_routespec)
         if v is None:
-            self.log.warning("Route %s doesn't exist. Nothing to delete", routespec)
-            return
+            self.log.warning("Route %s doesn't exist. Nothing to delete", jupyterhub_routespec)
+            return True, None
         target = v["Value"]
         escaped_target = escapism.escape(target, safe=self.key_safe_chars)
 

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -148,7 +148,7 @@ class TraefikEtcdProxy(TKvProxy):
         value = await maybe_future(self._etcd_get(jupyterhub_routespec))
         if value is None:
             self.log.warning("Route %s doesn't exist. Nothing to delete", jupyterhub_routespec)
-            return None, None
+            return True, None
 
         target = value.decode()
 

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -148,7 +148,7 @@ class TraefikEtcdProxy(TKvProxy):
         value = await maybe_future(self._etcd_get(jupyterhub_routespec))
         if value is None:
             self.log.warning("Route %s doesn't exist. Nothing to delete", jupyterhub_routespec)
-            return
+            return None, None
 
         target = value.decode()
 

--- a/jupyterhub_traefik_proxy/kv_proxy.py
+++ b/jupyterhub_traefik_proxy/kv_proxy.py
@@ -299,8 +299,6 @@ class TKvProxy(TraefikProxy):
         status, response = await self._kv_atomic_delete_route_parts(
             jupyterhub_routespec, route_keys
         )
-        if response is None:
-            return
         if status:
             self.log.info("Routespec %s was deleted.", routespec)
         else:

--- a/jupyterhub_traefik_proxy/kv_proxy.py
+++ b/jupyterhub_traefik_proxy/kv_proxy.py
@@ -299,7 +299,8 @@ class TKvProxy(TraefikProxy):
         status, response = await self._kv_atomic_delete_route_parts(
             jupyterhub_routespec, route_keys
         )
-
+        if response is None:
+            return
         if status:
             self.log.info("Routespec %s was deleted.", routespec)
         else:


### PR DESCRIPTION
when use etcd , route doesn't exist,  function  _kv_atomic_delete_route_parts will return None, which cause the problem in   "status, response = await self._kv_atomic_delete_route_parts"

use consule, reponse would be "" or str(e),
use etcd ,responses would be empity list or list of response 
for check reponse is None  for return

Closes #103 