### PR TITLE
Support automatic Let's Encrypt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ before_install:
   - pip install --upgrade setuptools pip
   - pip install --pre -r dev-requirements.txt --upgrade .
   - pip install pytest-cov
+  # Install pebble
   - go get -u github.com/letsencrypt/pebble/...
-  - cd $GOPATH/src/github.com/letsencrypt/pebble && go install ./...
+  - (cd $GOPATH/src/github.com/letsencrypt/pebble && go install ./...)
 install:
   - python -m jupyterhub_traefik_proxy.install --traefik --etcd --consul --output=./bin
   - export PATH=$PWD/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 language: python
 cache:
   - pip
+addons:
+  hosts:
+    - jupyter.test
 env:
   global:
     - ETCDCTL_API=3
+    - LEGO_CA_SERVER_NAME=pebble
+    - LEGO_CA_CERTIFICATES=$GOPATH/src/github.com/letsencrypt/pebble/test/certs/localhost/cert.pem
 
 # installing dependencies
 before_install:
   - pip install --upgrade setuptools pip
   - pip install --pre -r dev-requirements.txt --upgrade .
   - pip install pytest-cov
+  - go get -u github.com/letsencrypt/pebble/...
+  - cd $GOPATH/src/github.com/letsencrypt/pebble && go install ./...
 install:
   - python -m jupyterhub_traefik_proxy.install --traefik --etcd --consul --output=./bin
   - export PATH=$PWD/bin:$PATH

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -262,9 +262,10 @@ class TraefikProxy(Proxy):
             self.static_config["acme"] = acme
 
         if self.ssl_cert and self.ssl_key:
-            entryPoints["http"] = {"redirect": {"entrypoint": "https"}}
-
             self.static_config["defaultentrypoints"].append("https")
+
+            entryPoints["http"].update({"redirect": {"entrypoint": "https"}})
+
             entryPoints["https"] = {
                 "address": ":" + str(self.traefik_https_port),
                 "tls": {

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -94,6 +94,8 @@ class TraefikTomlProxy(TraefikProxy):
         try:
             if self.should_start:
                 os.remove(self.toml_static_config_file)
+                if self.traefik_auto_https:
+                    os.remove(self.traefik_acme_storage)
             os.remove(self.toml_dynamic_config_file)
         except:
             self.log.error("Failed to remove traefik's configuration files")

--- a/tests/config_files/pebble-config.json
+++ b/tests/config_files/pebble-config.json
@@ -1,0 +1,12 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "$GOPATH/src/github.com/letsencrypt/pebble/test/certs/localhost/cert.pem",
+    "privateKey": "$GOPATH/src/github.com/letsencrypt/pebble/test/certs/localhost/key.pem",
+    "httpPort": 8000,
+    "tlsPort": 8443,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,39 @@ from jupyterhub_traefik_proxy import TraefikTomlProxy
 
 
 @pytest.fixture
+async def autohttps_toml_proxy():
+    """Fixture returning a configured Let's Encrypt TraefikTomlProxy"""
+    proxy = TraefikTomlProxy(
+        public_url="http://127.0.0.1:8000",
+        traefik_api_password="admin",
+        traefik_api_username="api_admin",
+        should_start=True,
+        traefik_auto_https=True,
+        traefik_letsencrypt_email="jovyan@jupyter.test",
+        traefik_letsencrypt_domains=["jupyter.test"],
+        traefik_acme_server="https://0.0.0.0:14000/dir",
+        traefik_https_port=8443,
+    )
+
+    await proxy.start()
+    yield proxy
+    await proxy.stop()
+
+
+@pytest.fixture
+async def pebble():
+    pebble_server = subprocess.Popen(
+        ["pebble", "-config", "./tests/config_files/pebble-config.json"],
+        stdout=None,
+        stderr=None,
+    )
+    yield pebble_server
+
+    pebble_server.kill()
+    pebble_server.wait()
+
+
+@pytest.fixture
 async def no_auth_consul_proxy(consul_no_acl):
     """
     Fixture returning a configured TraefikConsulProxy.


### PR DESCRIPTION
This PR adds:
- [x] Support configuring acme when proxy is started by the Hub
   - http challenge only
- [x] Auto https test
  - using [pebble](https://github.com/letsencrypt/pebble) (thanks @consideRatio for helping out with this :heart: )
- [ ] Update docs

Closes #105 