### PR TITLE
ci: make pushing tags trigger release workflow properly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ name: Release
 # but only publish to PyPI on tags
 on:
   push:
-    tags: v?[0-9]+.[0-9]+.[0-9]+*
+    tags: "[0-9]+.[0-9]+.[0-9]+*"
     branches: master
 
 jobs:


### PR DESCRIPTION
I observed that I had misunderstood the use of `?` in the GitHub workflows regex.

`v?[0-9]+.[0-9]+.[0-9]+*` would trigger on "vX1.2.3` but not on `1.2.3` or `v1.2.3` for example. There seem to be no option to allow specifically just an optional v character in the beginning of the tag without also allowing for any character in the beginning of the tag.

Looking back at tags in this repo, I saw only 1.2.3 like tags, so I figure its fine to make the regex like this.