### PR TITLE
Update readthedocs config options and version

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,13 +1,18 @@
-name: jupyterhub-traefik-proxy
-type: sphinx
-requirements_file: docs/requirements.txt
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
 build:
   image: latest
+
 python:
-  version: 3.6
-  pip_install: true
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+    - requirements: docs/requirements.txt
+
 formats:
   - htmlzip
   - epub
-  # pdf disabled due to bug in sphinx 1.8 + recommonmark
-  # - pdf


### PR DESCRIPTION
- [x] We're still using the old readthedocs config version and Python 3.6. Some pkgs like `traitlets>5` have dropped support for it and this is why the docs build is failing. We should bump the python version we're telling rtd to use for the docs build.

Update: *Change the docs theme*  [I'll do this in a separate PR.]