### PR TITLE
Fix handling default server routes in TraefikTomlProxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+/bin

--- a/jupyterhub_traefik_proxy/consul.py
+++ b/jupyterhub_traefik_proxy/consul.py
@@ -165,7 +165,9 @@ class TraefikConsulProxy(TKvProxy):
 
         index, v = await self.kv_client.kv.get(escaped_jupyterhub_routespec)
         if v is None:
-            self.log.warning("Route %s doesn't exist. Nothing to delete", jupyterhub_routespec)
+            self.log.warning(
+                "Route %s doesn't exist. Nothing to delete", jupyterhub_routespec
+            )
             return True, None
         target = v["Value"]
         escaped_target = escapism.escape(target, safe=self.key_safe_chars)

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -147,7 +147,9 @@ class TraefikEtcdProxy(TKvProxy):
     async def _kv_atomic_delete_route_parts(self, jupyterhub_routespec, route_keys):
         value = await maybe_future(self._etcd_get(jupyterhub_routespec))
         if value is None:
-            self.log.warning("Route %s doesn't exist. Nothing to delete", jupyterhub_routespec)
+            self.log.warning(
+                "Route %s doesn't exist. Nothing to delete", jupyterhub_routespec
+            )
             return True, None
 
         target = value.decode()

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -248,19 +248,16 @@ class TraefikProxy(Proxy):
         self.static_config["api"] = {"dashboard": True, "entrypoint": "auth_api"}
         self.static_config["wss"] = {"protocol": "http"}
 
-
     def _routespec_to_traefik_path(self, routespec):
         path = self.validate_routespec(routespec)
-        if path != '/' and path.endswith('/'):
-            path = path.rstrip('/')
+        if path != "/" and path.endswith("/"):
+            path = path.rstrip("/")
         return path
 
-
     def _routespec_from_traefik_path(self, routespec):
-        if not routespec.endswith('/'):
-            routespec = routespec + '/'
+        if not routespec.endswith("/"):
+            routespec = routespec + "/"
         return routespec
-
 
     async def start(self):
         """Start the proxy.

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -51,9 +51,9 @@ class TraefikTomlProxy(TraefikProxy):
             self.routes_cache = traefik_utils.load_routes(self.toml_dynamic_config_file)
         except FileNotFoundError:
             self.routes_cache = {}
-        finally:
-            if not self.routes_cache:
-                self.routes_cache = {"backends": {}, "frontends": {}}
+
+        if not self.routes_cache:
+            self.routes_cache = {"backends": {}, "frontends": {}}
 
     async def _setup_traefik_static_config(self):
         await super()._setup_traefik_static_config()
@@ -100,8 +100,8 @@ class TraefikTomlProxy(TraefikProxy):
             raise
 
     def _get_route_unsafe(self, traefik_routespec):
-        safe = string.ascii_letters + string.digits + "-"
-        escaped_routespec = escapism.escape(traefik_routespec, safe=safe)
+        backend_alias = traefik_utils.generate_alias(traefik_routespec, "backend")
+        frontend_alias = traefik_utils.generate_alias(traefik_routespec, "frontend")
         routespec = self._routespec_from_traefik_path(traefik_routespec)
         result = {"data": "", "target": "", "routespec": routespec}
 
@@ -118,12 +118,12 @@ class TraefikTomlProxy(TraefikProxy):
                 if isinstance(v, dict):
                     get_target_data(v, to_find)
 
-        for key, value in self.routes_cache["backends"].items():
-            if escaped_routespec in key:
-                get_target_data(value, "url")
-        for key, value in self.routes_cache["frontends"].items():
-            if escaped_routespec in key:
-                get_target_data(value, "data")
+        if backend_alias in self.routes_cache["backends"]:
+            get_target_data(self.routes_cache["backends"][backend_alias], "url")
+
+        if frontend_alias in self.routes_cache["frontends"]:
+            get_target_data(self.routes_cache["frontends"][frontend_alias], "data")
+
         if not result["data"] and not result["target"]:
             self.log.info("No route for {} found!".format(routespec))
             result = None
@@ -214,18 +214,13 @@ class TraefikTomlProxy(TraefikProxy):
         **Subclasses must define this method**
         """
         routespec = self._routespec_to_traefik_path(routespec)
-        safe = string.ascii_letters + string.digits + "-"
-        escaped_routespec = escapism.escape(routespec, safe=safe)
+        backend_alias = traefik_utils.generate_alias(routespec, "backend")
+        frontend_alias = traefik_utils.generate_alias(routespec, "frontend")
 
         async with self.mutex:
-            for key, value in self.routes_cache["frontends"].items():
-                if escaped_routespec in key:
-                    del self.routes_cache["frontends"][key]
-                    break
-            for key, value in self.routes_cache["backends"].items():
-                if escaped_routespec in key:
-                    del self.routes_cache["backends"][key]
-                    break
+            self.routes_cache["frontends"].pop(frontend_alias, None)
+            self.routes_cache["backends"].pop(backend_alias, None)
+
         traefik_utils.persist_routes(self.toml_dynamic_config_file, self.routes_cache)
 
     async def get_all_routes(self):

--- a/performance/check_perf.py
+++ b/performance/check_perf.py
@@ -42,9 +42,9 @@ async def add_route_perf(proxy, route_idx, stdout_print):
 async def delete_route_perf(proxy, route_idx, stdout_print):
     """
     Computes time taken (ns) to delete the "route_idx"
-    route from the proxy's routing table (which 
+    route from the proxy's routing table (which
     contains route_idx + 1 routes when ran sequentially).
-    
+
     It assumes the route to be deleted exists.
 
     Returns a tuple:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -132,6 +132,7 @@ def test_linux_arm_platform(tmpdir):
     assert os.path.exists(deps_dir)
     assert_only_traefik_existence(deps_dir)
 
+
 def test_linux_amd64_platform(tmpdir):
     deps_dir = str(tmpdir.join("deps"))
     subprocess.run(

--- a/tests/test_traefik_api_auth.py
+++ b/tests/test_traefik_api_auth.py
@@ -48,5 +48,5 @@ async def test_traefik_api_auth(proxy, username, password, expected_rc):
         rc = None
     except Exception as e:
         rc = e.response.code
-    finally:
-        assert rc == expected_rc
+
+    assert rc == expected_rc

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,14 +27,14 @@ def is_open(ip, port):
 
 
 async def check_host_up(ip, port):
-    """ Check if the service opened the connection on the
-    designated port """
+    """Check if the service opened the connection on the
+    designated port"""
     return is_open(ip, port)
 
 
 async def get_responding_backend_port(traefik_url, path):
-    """ Check if traefik followed the configuration and routed the
-    request to the right backend """
+    """Check if traefik followed the configuration and routed the
+    request to the right backend"""
     if not path.endswith("/"):
         path += "/"
 


### PR DESCRIPTION
Hello.

I've faced an issue while using TraefikTomlProxy. Steps to reproduce:
1. Start Jupyterhub with TraefikTomlProxy used as default proxy class, and also enable named servers.
2. Go to home page and run 2 servers - one should be the default one (Start server button on top of the page), another should be a named server:
![изображение](https://user-images.githubusercontent.com/4661021/115850780-e5747e80-a42e-11eb-9016-e5e262b17280.png)
3. Open both the notebooks and check that they are started successfully
4. Stop default server by pressing Stop server button on the home page
5. Open the named server url. You've got 502 error from the Traefik
![изображение](https://user-images.githubusercontent.com/4661021/115850916-105ed280-a42f-11eb-82f1-7fe25c24cf7e.png)
8. After about 5 minutes the issue will dissapear, and you can now open this server

Why does this happen:
1. Named server's URL in proxy is `/user/msmarty5/proc`
2. Default server URL is `/user/msmarty5`
3. TraefikTomlProxy instead of searching and deleting rule in the route_cache by exact URL match uses condition `if prefix in url`:
https://github.com/jupyterhub/traefik-proxy/blob/397092bed1f7966a222a80930dbb507b301fbc84/jupyterhub_traefik_proxy/toml.py#L122
https://github.com/jupyterhub/traefik-proxy/blob/397092bed1f7966a222a80930dbb507b301fbc84/jupyterhub_traefik_proxy/toml.py#L126
https://github.com/jupyterhub/traefik-proxy/blob/397092bed1f7966a222a80930dbb507b301fbc84/jupyterhub_traefik_proxy/toml.py#L222
https://github.com/jupyterhub/traefik-proxy/blob/397092bed1f7966a222a80930dbb507b301fbc84/jupyterhub_traefik_proxy/toml.py#L226

It looks like the main reason for that was connected wit a fact, that rules are saved into `rules.toml` file in a format likes this:
```toml
[frontends.frontend__2Fuser_2Fmsmarty5_2Fproc.routes.test]
rule = "PathPrefix:/user/msmarty5/proc"
data = "{\"user\": \"msmarty5\", \"server_name\": \"proc\"}"
```
And rule string does not match the original URL exactly because of the prefix.

4. So then you stop server `/user/msmarty5` instead of removing exactly this route from Traefik it removes all the routes with `/user/me` prefix, including all the named servers like `/user/msmarty5/proc`
5. Each 5 minutes Jupyterhub calls `update_last_activity` method which causes updating all the mismatched proxy rules, and that leads to returning named server rule back:
https://github.com/jupyterhub/jupyterhub/blob/84d2e5de93ac3071361f86a7425ddf9ded6196e2/jupyterhub/app.py#L2700

This issue is not affecting etcd or consul proxy implementations, they are already using exact match by the URL.

In this PR I've added a fix for this issue.
Also I've added more cases into `test_add_get_delete`. Now for each URL case few additional routes with parent or child URLs will be added, and test check that they are accessible before and after removing the main route.