### PR TITLE
improve test time

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - name: Install build package
       run: |
         python -m pip install --upgrade pip
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build --sdist --wheel .
         ls -l dist
-    - name: Publish to PYPI
+    - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@v1.4.1
       if: startsWith(github.ref, 'refs/tags/')
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,16 @@ jobs:
       # Keep running even if one variation of the job fail
       fail-fast: false
       matrix:
-        python:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+        include:
+          - python: "3.7"
+          - python: "3.8"
+            backend: "etcd"
+          - python: "3.9"
+            backend: "consul"
+          - python: "3.10"
           # 3.11 tests don't work because etcd needs grpcio 1.44,
           # which doesn't support 3.11
-          # - "3.11"
+          # - python: "3.11"
     steps:
       # NOTE: In GitHub workflows, environment variables are set by writing
       #       assignment statements to a file. They will be set in the following
@@ -59,16 +61,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      # Test pkg build for python 3.8
-      - name: Install requirements and build package
-        if: matrix.python == '3.8'
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-          pip freeze
-          python -m build --sdist --wheel .
-          ls -l dist
-
       - name: Install Python dependencies
         run: |
           pip install --upgrade setuptools pip
@@ -76,10 +68,20 @@ jobs:
           python -m jupyterhub_traefik_proxy.install --traefik --etcd --consul --output=./bin
           pip freeze
 
+      - name: Select tests
+        run: |
+          if [[ ! -z "${{ matrix.backend }}" ]]; then
+            # select backend subset
+            echo "PYTEST_ADDOPTS=-k ${{ matrix.backend }}" >> "${GITHUB_ENV}"
+          else
+            # default: select everything _but_ the etcd/consul backend tests
+            echo "PYTEST_ADDOPTS=-k 'not etcd and not consul'" >> "${GITHUB_ENV}"
+          fi
+
       - name: Run tests
         run: |
           # Using the "--slow-last" flag, should run the slow tests last
-          pytest -v tests --maxfail 3 --slow-last --color=yes --cov=jupyterhub_traefik_proxy
+          pytest -v --durations 10 --maxfail 3 --slow-last --color=yes --cov=jupyterhub_traefik_proxy tests
 
       - name: Submit codecov report
         run: |

--- a/jupyterhub_traefik_proxy/consul.py
+++ b/jupyterhub_traefik_proxy/consul.py
@@ -88,7 +88,8 @@ class TraefikConsulProxy(TKvProxy):
             provider_config["consul"].update({"username": self.kv_username})
 
         if self.kv_password:
-            provider_config["consul"].update({"password": self.kv_password})
+            key = "password" if self.kv_username else "token"
+            provider_config["consul"].update({key: self.kv_password})
 
         # FIXME: Same with the tls info
         if self.consul_client_ca_cert:
@@ -97,7 +98,7 @@ class TraefikConsulProxy(TKvProxy):
             }
 
         self.static_config.update({"providers": provider_config})
-            
+
     def _start_traefik(self):
         os.environ["CONSUL_HTTP_TOKEN"] = self.kv_password
         super()._start_traefik()

--- a/jupyterhub_traefik_proxy/consul.py
+++ b/jupyterhub_traefik_proxy/consul.py
@@ -80,16 +80,6 @@ class TraefikConsulProxy(TKvProxy):
                 ]
             }
         }
-        # Q: Why weren't these in the Traefik v1 implementation?
-        # A: Although defined in the traefik docs, they appear to
-        # do nothing, and CONSUL_HTTP_TOKEN needs to be used instead.
-        # Ref: https://github.com/traefik/traefik/issues/767#issuecomment-270096663
-        if self.kv_username:
-            provider_config["consul"].update({"username": self.kv_username})
-
-        if self.kv_password:
-            key = "password" if self.kv_username else "token"
-            provider_config["consul"].update({key: self.kv_password})
 
         # FIXME: Same with the tls info
         if self.consul_client_ca_cert:
@@ -100,13 +90,17 @@ class TraefikConsulProxy(TKvProxy):
         self.static_config.update({"providers": provider_config})
 
     def _start_traefik(self):
-        os.environ["CONSUL_HTTP_TOKEN"] = self.kv_password
+        if self.kv_password:
+            if self.kv_username:
+                self.traefik_env.setdefault(
+                    "CONSUL_HTTP_AUTH", f"{self.kv_username}:{self.kv_password}"
+                )
+            else:
+                self.traefik_env.setdefault("CONSUL_HTTP_TOKEN", self.kv_password)
         super()._start_traefik()
 
     def _stop_traefik(self):
         super()._stop_traefik()
-        if "CONSUL_HTTP_TOKEN" in os.environ:
-            os.environ.pop("CONSUL_HTTP_TOKEN")
 
     async def persist_dynamic_config(self):
         data = self.flatten_dict_for_kv(

--- a/jupyterhub_traefik_proxy/install.py
+++ b/jupyterhub_traefik_proxy/install.py
@@ -33,9 +33,10 @@ checksums_etcd = {
 }
 
 checksums_consul = {
-    "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_linux_amd64.zip": "da3919197ef33c4205bb7df3cc5992ccaae01d46753a72fe029778d7f52fb610",
-    "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_linux_arm64.zip": "012c552aff502f907416c9a119d2dfed88b92e981f9b160eb4fe292676afdaeb",
-    "https://releases.hashicorp.com/consul/1.9.4/consul_1.9.4_darwin.zip": "c168240d52f67c71b30ef51b3594673cad77d0dbbf38c412b2ee30b39ef30843",
+    "https://releases.hashicorp.com/consul/1.14.4/consul_1.14.4_darwin_amd64.zip": "694b8edc470838d8a73df08d6c616d25b54724abad410fa27c83697b372a2cfc",
+    "https://releases.hashicorp.com/consul/1.14.4/consul_1.14.4_darwin_arm64.zip": "330ddff6d6cc16ce091b8f25a4abd0f1984d88f10e272efcec52e01aaaa1b3b0",
+    "https://releases.hashicorp.com/consul/1.14.4/consul_1.14.4_linux_arm64.zip": "9baf47a75c95945824da0629bc0b3f7b1ca55015e8c9ce7579d9a431a90b721c",
+    "https://releases.hashicorp.com/consul/1.14.4/consul_1.14.4_linux_amd64.zip": "eafb7c853ce9cc1536bffa99325f8df365ff70a3b83c037836e63964a8adfd7a",
     "https://releases.hashicorp.com/consul/1.6.1/consul_1.6.1_linux_amd64.zip": "a8568ca7b6797030b2c32615b4786d4cc75ce7aee2ed9025996fe92b07b31f7e",
     "https://releases.hashicorp.com/consul/1.6.1/consul_1.6.1_darwin_amd64.zip": "4bc205e06b2921f998cb6ddbe70de57f8e558e226e44aba3f337f2f245678b85",
     "https://releases.hashicorp.com/consul/1.5.0/consul_1.5.0_linux_amd64.zip": "1399064050019db05d3378f757e058ec4426a917dd2d240336b51532065880b6",
@@ -133,11 +134,11 @@ def install_etcd(prefix, plat, etcd_version):
     )
 
     if os.path.exists(etcd_bin) and os.path.exists(etcdctl_bin):
-        print(f"Etcd and etcdctl already exist")
+        print("Etcd and etcdctl already exist")
         if etcd_url not in checksums_etcd:
             warnings.warn(
-                f"Etcd {etcd_version} not supported ! Or, at least, we don't "
-                f"recognise {etcd_url} in our checksums", stacklevel=2,
+                f"Etcd {etcd_version} at {etcd_url} checksum cannot be verified",
+                stacklevel=2,
             )
             os.chmod(etcd_bin, 0o755)
             os.chmod(etcdctl_bin, 0o755)
@@ -168,8 +169,7 @@ def install_etcd(prefix, plat, etcd_version):
             raise IOError("Checksum failed")
     else:
         warnings.warn(
-            f"Etcd {etcd_version} not supported ! Or, at least, we don't "
-            f"recognise {etcd_url} in our checksums",
+            f"Skipping checksum verification of unknown etcd {etcd_version}",
             stacklevel=2
         )
 
@@ -216,8 +216,7 @@ def install_consul(prefix, plat, consul_version):
         print(f"Consul already exists")
         if consul_url not in checksums_consul:
             warnings.warn(
-                f"Consul {consul_version} not supported ! Or, at least we don't have "
-                f"it {consul_url} in our checksums",
+                f"Skipping checksum verification of unknown consul {consul_version}",
                 stacklevel=2,
             )
             os.chmod(consul_bin, 0o755)
@@ -252,8 +251,7 @@ def install_consul(prefix, plat, consul_version):
         shutil.rmtree(consul_binaries)
     else:
         warnings.warn(
-            f"Consul {consul_version} not supported ! Or, at least we don't have "
-            f"it {consul_url} in our checksums",
+            f"Consul {consul_version} at {consul_url} checksum cannot be verified",
             stacklevel=2,
         )
 
@@ -286,9 +284,10 @@ def main():
                 - v3.2.26-linux-amd64
                 - v3.2.26-darwin-amd64
             - consul:
-                - v1.9.4_darwin
-                - v1.9.4_linux_amd64
-                - v1.9.4_linux_arm64
+                - v1.14.4_darwin_amd64
+                - v1.14.4_darwin_arm64
+                - v1.14.4_linux_amd64
+                - v1.14.4_linux_arm64
                 - v1.6.1_linux_amd64
                 - v1.6.1_darwin_amd64
                 - v1.5.0_linux_amd64
@@ -389,7 +388,7 @@ def main():
     parser.add_argument(
         "--consul-version",
         dest="consul_version",
-        default="1.9.4",
+        default="1.14.4",
         help=textwrap.dedent(
             """\
             The version of consul to download.

--- a/tests/config_files/consul_config.json
+++ b/tests/config_files/consul_config.json
@@ -1,11 +1,8 @@
 {
-    "data_dir": "./consul.data",
     "server": true,
     "acl": {
         "enabled": true,
         "default_policy": "deny",
-        "enable_token_replication": true,
-        "enable_token_persistence": true,
         "tokens" : {
             "initial_management": "secret",
             "default" : "secret"

--- a/tests/config_files/consul_config.json
+++ b/tests/config_files/consul_config.json
@@ -4,8 +4,11 @@
     "acl": {
         "enabled": true,
         "default_policy": "deny",
+        "enable_token_replication": true,
+        "enable_token_persistence": true,
         "tokens" : {
-            "master" : "secret"
+            "initial_management": "secret",
+            "default" : "secret"
         }
     }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,7 +341,6 @@ def launch_traefik_consul():
 @pytest.fixture
 def launch_traefik_consul_auth():
     extra_args = (
-        "--providers.consul.token=" + Config.consul_token,
         f"--providers.consul.endpoints=http://127.0.0.1:{Config.consul_auth_port}",
     )
     traefik_env = os.environ.copy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -585,11 +585,6 @@ def _config_consul(secret=None, port=8500):
 #########################################################################
 
 def shutdown_consul(consul_proc, secret=None, port=8500):
-    consul_env = None
-    if secret is not None:
-        consul_env = os.environ.copy()
-        consul_env.update({"CONSUL_HTTP_TOKEN" : secret})
-    subprocess.call(["consul", "leave", f"-http-addr=http://127.0.0.1:{port}"], env=consul_env)
     terminate_process(consul_proc, timeout=30)
 
 def shutdown_etcd(etcd_proc):

--- a/tests/proxytest.py
+++ b/tests/proxytest.py
@@ -218,8 +218,8 @@ async def test_add_get_delete(
             responding_backend2 = await utils.get_responding_backend_port(
                 proxy_url, normalize_spec(spec) + "something"
             )
-            assert_equal(responding_backend1, backend.port)
-            assert_equal(responding_backend2, backend.port)
+            assert responding_backend1 == backend.port
+            assert responding_backend2 == backend.port
 
     for i, spec in enumerate(existing_routes, start=1):
         backend = default_backend._replace(
@@ -362,24 +362,24 @@ async def test_host_origin_headers(proxy, launch_backend):
     default_backend_port = 9000
     launch_backend(default_backend_port)
 
+    # wait for traefik to be reachable
     await exponential_backoff(
-        utils.check_host_up, "Traefik not reacheable", ip="localhost", port=traefik_port
+        utils.check_host_up_http,
+        "Traefik not reacheable",
+        url=f"http://localhost:{traefik_port}/",
     )
 
-    # Check if default backend is reacheable
+    # wait for backend to be reachable
     await exponential_backoff(
-        utils.check_host_up,
+        utils.check_host_up_http,
         "Backends not reacheable",
-        ip="localhost",
-        port=default_backend_port,
+        url=f"http://localhost:{default_backend_port}/",
     )
+
     # Add route to default_backend
     await proxy.add_route(routespec, target, data)
 
-    if proxy.public_url.endswith("/"):
-        req_url = proxy.public_url[:-1] + routespec
-    else:
-        req_url = proxy.public_url + routespec
+    req_url = proxy.public_url.rstrip("/") + routespec
 
     expected_host_header = traefik_host + ":" + str(traefik_port)
     expected_origin_header = proxy.public_url + routespec
@@ -392,8 +392,8 @@ async def test_host_origin_headers(proxy, launch_backend):
     )
     resp = await AsyncHTTPClient().fetch(req)
 
-    assert_equal(resp.headers["Host"], expected_host_header)
-    assert_equal(resp.headers["Origin"], expected_origin_header)
+    assert resp.headers["Host"] == expected_host_header
+    assert resp.headers["Origin"] == expected_origin_header
 
 
 @pytest.mark.parametrize("username", ["zoe", "50fia", "秀樹", "~TestJH", "has@"])
@@ -407,7 +407,7 @@ async def test_check_routes(proxy, username):
     # run initial check first, to ensure that `/` is in the routes
     await proxy.check_routes(users, services)
     routes = await proxy.get_all_routes()
-    assert_equal(sorted(routes), ["/"])
+    assert sorted(routes) == ["/"]
 
     users[username] = test_user = MockUser(username)
     spawner = test_user.spawners[""]
@@ -451,17 +451,20 @@ async def test_websockets(proxy, launch_backend):
     default_backend_port = 9000
     launch_backend(default_backend_port, "ws")
 
+    # wait for traefik to be reachable
     await exponential_backoff(
-        utils.check_host_up, "Traefik not reacheable", ip="127.0.0.1", port=traefik_port
+        utils.check_host_up_http,
+        "Traefik not reacheable",
+        url=f"http://localhost:{traefik_port}/",
     )
 
-    # Check if default backend is reacheable
+    # wait for backend to be reachable
     await exponential_backoff(
-        utils.check_host_up,
-        "Backend not reacheable",
-        ip="127.0.0.1",
-        port=default_backend_port,
+        utils.check_host_up_http,
+        "Backends not reacheable",
+        url=f"http://localhost:{default_backend_port}/",
     )
+
     # Add route to default_backend
     await proxy.add_route(routespec, target, data)
 


### PR DESCRIPTION
- [x] thin build matrix (avoid running all backends in any given run)
- [x] show durations so we can see where the time is spent
- [x] add some concurrency for slow calls like sequential `add_route`
- [x] allow longer-running traefik/etcd/consul to avoid startup costs applied to every single test (note: only consul so far)

closes #148