### PR TITLE
switch etcd3 client for Python 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,7 @@ jobs:
           - python: "3.9"
             backend: "consul"
           - python: "3.10"
-          # 3.11 tests don't work because etcd needs grpcio 1.44,
-          # which doesn't support 3.11
-          # - python: "3.11"
+          - python: "3.11"
     steps:
       # NOTE: In GitHub workflows, environment variables are set by writing
       #       assignment statements to a file. They will be set in the following

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,10 @@ notebook>=4.0
 websockets
 # etcd3 & python-consul2 are now soft dependencies
 # Adding them here prevents CI from failing
-etcd3
+
+# python-etcd3 is unmaintained, but there are several forks
+# all the forks (at this point) install the same python module,
+# but with updated grpcio compatibility
+# watch this space to pick a winner...
+etcdpy
 python-consul2
-grpcio

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -90,7 +90,7 @@ class TraefikEtcdProxy(TKvProxy):
         try:
             import etcd3
         except ImportError:
-            raise ImportError("Please install etcd3 package to use traefik-proxy with etcd3")
+            raise ImportError("Please install etcd3 or etcdpy package to use traefik-proxy with etcd3")
         kwargs = {
             'host': etcd_service.hostname,
             'port': etcd_service.port,
@@ -191,7 +191,7 @@ class TraefikEtcdProxy(TKvProxy):
         if not self.traefik_entrypoint:
             self.traefik_entrypoint = await self._get_traefik_entrypoint()
         success.append(put(ep_path, self.traefik_entrypoint))
-                
+
         status, response = await maybe_future(self._etcd_transaction(success))
         return status, response
 
@@ -271,4 +271,3 @@ class TraefikEtcdProxy(TKvProxy):
             transactions.append(self.kv_client.transactions.put(k, v))
         status, response = await maybe_future(self._etcd_transaction(transactions))
         return status, response
-

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -328,7 +328,7 @@ class TraefikProxy(Proxy):
         try:
             self.log.debug(f"Persisting the static config: {self.static_config}")
             handler = traefik_utils.TraefikConfigFileHandler(self.static_config_file)
-            handler.dump(self.static_config)
+            handler.atomic_dump(self.static_config)
         except IOError:
             self.log.exception("Couldn't set up traefik's static config.")
             raise

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -134,7 +134,8 @@ def atomic_writing(path):
             # already deleted by os.replace above
             pass
 
-class TraefikConfigFileHandler(object):
+
+class TraefikConfigFileHandler:
     """Handles reading and writing Traefik config files. Can operate
     on both toml and yaml files"""
     def __init__(self, file_path):
@@ -144,7 +145,7 @@ class TraefikConfigFileHandler(object):
                 from ruamel.yaml import YAML
             except ImportError:
                 raise ImportError("jupyterhub-traefik-proxy requires ruamel.yaml to use YAML config files")
-            config_handler = YAML(typ="safe")
+            config_handler = YAML(typ="rt")
         elif file_ext == 'toml':
             import toml as config_handler
         else:


### PR DESCRIPTION
not a great situation right now, with ~all etcd3 and consul clients being unmaintained. grpc-python as a whole seems to be in a pretty unhealthy situation.