### PR TITLE
Deprecations for v2 upgrades

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
   # Run "pytest tests" for various Python versions
   pytest:
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     strategy:
       # Keep running even if one variation of the job fail
       fail-fast: false

--- a/docs/source/consul.md
+++ b/docs/source/consul.md
@@ -88,7 +88,7 @@ You can choose to:
         c.TraefikConsulProxy.consul_url = "scheme://hostname:port"
         ```
       * consul **credentials** (if consul has acl enabled)
-        ```pythno
+        ```python
           c.TraefikConsulProxy.consul_password = "123"
         ```
 

--- a/docs/source/consul.md
+++ b/docs/source/consul.md
@@ -69,30 +69,30 @@ You can choose to:
 3. By **default**, TraefikConsulProxy assumes consul accepts client requests on the official **default** consul port `8500` for client requests.
 
     ```python
-    c.TraefikConsulProxy.kv_url = "http://127.0.0.1:8500"
+    c.TraefikConsulProxy.consul_url = "http://127.0.0.1:8500"
     ```
 
-    If the consul cluster is deployed differently than using the consul defaults, then you **must** pass the consul url to the proxy using 
-    the `kv_url` option in *jupyterhub_config.py*:
+    If the consul cluster is deployed differently than using the consul defaults, then you **must** pass the consul url to the proxy using
+    the `consul_url` option in *jupyterhub_config.py*:
 
     ```python
-    c.TraefikConsulProxy.kv_url = "scheme://hostname:port"
+    c.TraefikConsulProxy.consul_url = "scheme://hostname:port"
     ```
 
     ```{note}
     **TraefikConsulProxy does not manage the consul cluster** and assumes it is up and running before the proxy itself starts.
-    However, based on how consul is configured and started, TraefikConsulProxy needs to be told about 
+    However, based on how consul is configured and started, TraefikConsulProxy needs to be told about
     some consul configuration details, such as:
       * consul **address** where it accepts client requests
-        ```
-          c.TraefikConsulProxy.kv_url="scheme://hostname:port"
+        ```python
+        c.TraefikConsulProxy.consul_url = "scheme://hostname:port"
         ```
       * consul **credentials** (if consul has acl enabled)
-        ```
-          c.TraefikConsulProxy.kv_password="123"
+        ```pythno
+          c.TraefikConsulProxy.consul_password = "123"
         ```
 
-    Checkout the [consul documentation](https://learn.hashicorp.com/consul/) 
+    Checkout the [consul documentation](https://learn.hashicorp.com/consul/)
     to find out more about possible consul configuration options.
     ```
 
@@ -118,14 +118,14 @@ If TraefikConsulProxy is used as an externally managed service, then make sure y
    c.TraefikConsulProxy.should_start = False
 
    # if not the default:
-   c.TraefikConsulProxy.kv_url = "http://consul-host:2379"
+   c.TraefikConsulProxy.consul_url = "http://consul-host:2379"
 
    # traefik api credentials
    c.TraefikConsulProxy.traefik_api_username = "abc"
    c.TraefikConsulProxy.traefik_api_password = "123"
 
    # consul acl token
-   c.TraefikConsulProxy.kv_password = "456"
+   c.TraefikConsulProxy.consul_password = "456"
    ```
 
 3. Create a *toml* file with traefik's desired static configuration
@@ -198,17 +198,17 @@ This is an example setup for using JupyterHub and TraefikConsulProxy managed by 
    c.TraefikConsulProxy.traefik_api_username = "123"
 
    # consul url where it accepts client requests
-   c.TraefikConsulProxy.kv_url = "path/to/rules.toml"
+   c.TraefikConsulProxy.consul_url = "path/to/rules.toml"
 
    # configure JupyterHub to use TraefikConsulProxy
    c.JupyterHub.proxy_class = TraefikConsulProxy
    ```
 
     ```{note}
-    If you intend to enable consul acl, add the acl token to *jupyterhub_config.py* under *kv_password*:
+    If you intend to enable consul acl, add the acl token to *jupyterhub_config.py* under *consul_password*:
 
         # consul token
-        c.TraefikConsulProxy.kv_password = "456"
+        c.TraefikConsulProxy.consul_password = "456"
     ```
 
 2. Starts the agent in development mode on the default port on localhost. e.g.:
@@ -242,7 +242,7 @@ This is an example setup for using JupyterHub and TraefikConsulProxy managed by 
     # the port on localhost where the traefik api and dashboard can be found
     [entryPoints.auth_api]
     address = ":8099"
-    
+
     # authenticate the traefik api entrypoint
     [entryPoints.auth_api.auth.basic]
     users = [ "abc:$apr1$eS/j3kum$q/X2khsIEG/bBGsteP.x./",]

--- a/docs/source/etcd.md
+++ b/docs/source/etcd.md
@@ -69,36 +69,36 @@ You can choose to:
 3. By **default**, TraefikEtcdProxy assumes etcd accepts client requests on the official **default** etcd port `2379` for client requests.
 
     ```python
-    c.TraefikEtcdProxy.kv_url = "http://127.0.0.1:2379"
+    c.TraefikEtcdProxy.etcd_url = "http://127.0.0.1:2379"
     ```
 
-    If the etcd cluster is deployed differently than using the etcd defaults, then you **must** pass the etcd url to the proxy using 
-    the `kv_url` option in *jupyterhub_config.py*:
+    If the etcd cluster is deployed differently than using the etcd defaults, then you **must** pass the etcd url to the proxy using
+    the `etcd_url` option in *jupyterhub_config.py*:
 
     ```python
-    c.TraefikEtcdProxy.kv_url = "scheme://hostname:port"
+    c.TraefikEtcdProxy.etcd_url = "scheme://hostname:port"
     ```
 
 ```{note}
 
 1. **TraefikEtcdProxy does not manage the etcd cluster** and assumes it is up and running before the proxy itself starts.
 
-   However, based on how etcd is configured and started, TraefikEtcdProxy needs to be told about 
+   However, based on how etcd is configured and started, TraefikEtcdProxy needs to be told about
    some etcd configuration details, such as:
    * etcd **address** where it accepts client requests
      ```
-     c.TraefikEtcdProxy.kv_url="scheme://hostname:port"
+     c.TraefikEtcdProxy.etcd_url="scheme://hostname:port"
      ```
    * etcd **credentials** (if etcd has authentication enabled)
      ```
-     c.TraefikEtcdProxy.kv_username="abc"
-     c.TraefikEtcdProxy.kv_password="123"
+     c.TraefikEtcdProxy.etcd_username="abc"
+     c.TraefikEtcdProxy.etcd_password="123"
      ```
 
-2. Etcd has two API versions: the API V3 and the API V2. Traefik suggests using Etcd API V3, 
+2. Etcd has two API versions: the API V3 and the API V2. Traefik suggests using Etcd API V3,
 because the API V2 won't be supported in the future.
 
-   Checkout the [etcd documentation](https://coreos.com/etcd/docs/latest/op-guide/configuration.html) 
+   Checkout the [etcd documentation](https://coreos.com/etcd/docs/latest/op-guide/configuration.html)
 to find out more about possible etcd configuration options.
 ```
 
@@ -124,15 +124,15 @@ If TraefikEtcdProxy is used as an externally managed service, then make sure you
    c.TraefikEtcdProxy.should_start = False
 
    # if not the default:
-   c.TraefikEtcdProxy.kv_url = "http://etcd-host:2379"
+   c.TraefikEtcdProxy.etcd_url = "http://etcd-host:2379"
 
    # traefik api credentials
    c.TraefikEtcdProxy.traefik_api_username = "abc"
    c.TraefikEtcdProxy.traefik_api_password = "123"
 
    # etcd credentials
-   c.TraefikEtcdProxy.kv_username = "def"
-   c.TraefikEtcdProxy.kv_password = "456"
+   c.TraefikEtcdProxy.etcd_username = "def"
+   c.TraefikEtcdProxy.etcd_password = "456"
    ```
 
 3. Create a *toml* file with traefik's desired static configuration
@@ -207,7 +207,7 @@ This is an example setup for using JupyterHub and TraefikEtcdProxy managed by an
    c.TraefikEtcdProxy.traefik_api_username = "123"
 
    # etcd url where it accepts client requests
-   c.TraefikEtcdProxy.kv_url = "path/to/rules.toml"
+   c.TraefikEtcdProxy.etcd_url = "http://127.0.0.1:2379"
 
    # configure JupyterHub to use TraefikEtcdProxy
    c.JupyterHub.proxy_class = TraefikEtcdProxy
@@ -218,9 +218,9 @@ This is an example setup for using JupyterHub and TraefikEtcdProxy managed by an
     If you intend to enable authentication on etcd, add the etcd credentials to *jupyterhub_config.py*:
 
         # etcd username
-        c.TraefikEtcdProxy.kv_username = "def"
+        c.TraefikEtcdProxy.etcd_username = "def"
         # etcd password
-        c.TraefikEtcdProxy.kv_password = "456"
+        c.TraefikEtcdProxy.etcd_password = "456"
     ```
 
 2. Start a single-note etcd cluster on the default port on localhost. e.g.:
@@ -255,7 +255,7 @@ This is an example setup for using JupyterHub and TraefikEtcdProxy managed by an
     # the port on localhost where the traefik api and dashboard can be found
     [entryPoints.auth_api]
     address = ":8099"
-    
+
     # authenticate the traefik api entrypoint
     [entryPoints.auth_api.auth.basic]
     users = [ "abc:$apr1$eS/j3kum$q/X2khsIEG/bBGsteP.x./",]

--- a/docs/source/file.md
+++ b/docs/source/file.md
@@ -36,7 +36,7 @@ You can choose to:
 Traefik's configuration is divided into two parts:
 
 * The **static** configuration (loaded only at the beginning)
-* The **dynamic** configuration (can be hot-reloaded, without restarting the proxy), 
+* The **dynamic** configuration (can be hot-reloaded, without restarting the proxy),
 where the routing table will be updated continuously.
 
 Traefik allows us to have one file for the static configuration file (`traefik.toml` or `traefik.yaml`) and one or several files for the routes, that traefik would watch.
@@ -55,20 +55,20 @@ By **default**, Traefik will search for `traefik.toml` and `rules.toml` in the f
 You can override this in TraefikFileProviderProxy, by modifying the **static_config_file** argument:
 
 ```python
-c.TraefikFileProviderProxy.static_config_file="/path/to/static_config_filename.toml"
+c.TraefikFileProviderProxy.static_config_file = "/path/to/static_config_filename.toml"
 ```
 
 Similarly, you can override the dynamic configuration file by modifying the **dynamic_config_file** argument:
 
 ```python
-c.TraefikFileProviderProxy.dynamic_config_file="/path/to/dynamic_config_filename.toml"
+c.TraefikFileProviderProxy.dynamic_config_file = "/path/to/dynamic_config_filename.toml"
 ```
 
 ```{note}
 
-* **When JupyterHub starts the proxy**, it writes the static config once, then only edits the dynamic config file. 
+* **When JupyterHub starts the proxy**, it writes the static config once, then only edits the dynamic config file.
 
-* **When JupyterHub does not start the proxy**, the user is totally responsible for the static config and 
+* **When JupyterHub does not start the proxy**, the user is totally responsible for the static config and
 JupyterHub is responsible exclusively for the routes.
 
 * **When JupyterHub does not start the proxy**, the user should tell `traefik` to get its dynamic configuration
@@ -79,15 +79,14 @@ will be managed by JupyterHub. This allows e.g., the administrator to configure 
 
 ## Externally managed TraefikFileProviderProxy
 
-When TraefikFileProviderProxy is externally managed, service managers like [systemd](https://www.freedesktop.org/wiki/Software/systemd/) 
+When TraefikFileProviderProxy is externally managed, service managers like [systemd](https://www.freedesktop.org/wiki/Software/systemd/)
 or [docker](https://www.docker.com/) will be responsible for starting and stopping the proxy.
 
 If TraefikFileProviderProxy is used as an externally managed service, then make sure you follow the steps enumerated below:
 
 1. Let JupyterHub know that the proxy being used is TraefikFileProviderProxy, using the *proxy_class* configuration option:
     ```python
-    from jupyterhub_traefik_proxy.fileprovider import TraefikFileProviderProxy
-    c.JupyterHub.proxy_class = TraefikFileProviderProxy
+    c.JupyterHub.proxy_class = "traefik_file"
     ```
 
 2. Configure `TraefikFileProviderProxy` in **jupyterhub_config.py**
@@ -152,13 +151,12 @@ If TraefikFileProviderProxy is used as an externally managed service, then make 
    * Check `tests/config_files/traefik.toml` for an example.
 
 ## Example setup
-   
+
 This is an example setup for using JupyterHub and TraefikFileProviderProxy managed by another service than JupyterHub.
 
 1. Configure the proxy through the JupyterHub configuration file, *jupyterhub_config.py*, e.g.:
 
    ```python
-   from jupyterhub_traefik_proxy import TraefikFileProviderProxy
 
    # mark the proxy as externally managed
    c.TraefikFileProviderProxy.should_start = False
@@ -173,7 +171,7 @@ This is an example setup for using JupyterHub and TraefikFileProviderProxy manag
    c.TraefikFileProviderProxy.dynamic_config_file = "/var/run/traefik/rules.toml"
 
    # configure JupyterHub to use TraefikFileProviderProxy
-   c.JupyterHub.proxy_class = TraefikFileProviderProxy
+   c.JupyterHub.proxy_class = "traefik_file"
     ```
 
 2. Create a traefik static configuration file, *traefik.toml*, e.g.:

--- a/jupyterhub_traefik_proxy/consul.py
+++ b/jupyterhub_traefik_proxy/consul.py
@@ -18,20 +18,15 @@ Route Specification:
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import json
-import os
 from urllib.parse import urlparse
-import string
 import base64
+import string
+import warnings
 
-import asyncio
 import escapism
-from tornado.concurrent import run_on_executor
-from traitlets import Any, default, Unicode
+from traitlets import default, observe, Any, Unicode
 
-from . import traefik_utils
 from .kv_proxy import TKvProxy
-import time
 
 
 class TraefikConsulProxy(TKvProxy):
@@ -51,52 +46,69 @@ class TraefikConsulProxy(TKvProxy):
         help="""Consul client root certificates""",
     )
 
-    @default("kv_url")
-    def _default_kv_url(self):
-        return "http://127.0.0.1:8500"
+    consul_url = Unicode(
+        "http://127.0.0.1:8500",
+        config=True,
+        help="URL for the consul endpoint.",
+    )
+    consul_username = Unicode(
+        "",
+        config=True,
+        help="URL for the consul endpoint.",
+    )
 
-    @default("kv_client")
+    kv_url = Unicode("DEPRECATED", config=True)
+    kv_username = Unicode("DEPRECATED", config=True)
+    kv_password = Unicode("DEPRECATED", config=True)
+
+    @observe("kv_url", "kv_username", "kv_password")
+    def _deprecated_config(self, change):
+        new_name = change.name.replace("kv_", "consul_")
+        warnings.warn(
+            f"TraefikConsulProxy.{change.name} is deprecated in 0.4. Use TraefikEtcdProxy.{new_name} = {change.new!r}"
+        )
+        setattr(self, new_name, change.new)
+
+    consul = Any()
+
+    @default("consul")
     def _default_client(self):
         try:
             import consul.aio
         except ImportError:
             raise ImportError("Please install python-consul2 package to use traefik-proxy with consul")
-        consul_service = urlparse(self.kv_url)
+        consul_service = urlparse(self.consul_url)
         kwargs = {
-            'host': consul_service.hostname,
-            'port': consul_service.port,
-            'cert': self.consul_client_ca_cert
+            "host": consul_service.hostname,
+            "port": consul_service.port,
+            "cert": self.consul_ca_cert,
         }
-        if self.kv_password:
-            kwargs.update({'token': self.kv_password})
+        if self.consul_password:
+            kwargs.update({"token": self.consul_password})
         return consul.aio.Consul(**kwargs)
 
     def _define_kv_specific_static_config(self):
         provider_config = {
             "consul": {
                 "rootKey": self.kv_traefik_prefix,
-                "endpoints" : [
-                    urlparse(self.kv_url).netloc
-                ]
+                "endpoints": [urlparse(self.consul_url).netloc],
             }
         }
 
         # FIXME: Same with the tls info
-        if self.consul_client_ca_cert:
-            provider_config["consul"]["tls"] = {
-                "ca" : self.consul_client_ca_cert
-            }
+        if self.consul_ca_cert:
+            provider_config["consul"]["tls"] = {"ca": self.consul_ca_cert}
 
         self.static_config.update({"providers": provider_config})
 
     def _start_traefik(self):
-        if self.kv_password:
-            if self.kv_username:
+        if self.consul_password:
+            if self.consul_username:
                 self.traefik_env.setdefault(
-                    "CONSUL_HTTP_AUTH", f"{self.kv_username}:{self.kv_password}"
+                    "CONSUL_HTTP_AUTH", f"{self.consul_username}:{self.consul_password}"
                 )
             else:
-                self.traefik_env.setdefault("CONSUL_HTTP_TOKEN", self.kv_password)
+                self.traefik_env.setdefault("CONSUL_HTTP_TOKEN", self.consul_password)
         super()._start_traefik()
 
     def _stop_traefik(self):
@@ -119,14 +131,13 @@ class TraefikConsulProxy(TKvProxy):
             append_payload(k, v)
 
         try:
-            results = await self.kv_client.txn.put(payload=payload)
+            results = await self.consul.txn.put(payload=payload)
             status = 1
             response = ""
         except Exception as e:
             status = 0
             response = str(e)
             self.log.exception(f"Error uploading payload to KV store!\n{response}")
-            self.log.exception(f"Are you missing a token? {self.kv_client.token}")
         else:
             self.log.debug("Successfully uploaded payload to KV store")
 
@@ -170,9 +181,9 @@ class TraefikConsulProxy(TKvProxy):
         entrypoint_path = self.kv_separator.join([router_path, "entryPoints", "0"])
         append_payload(entrypoint_path, self.traefik_entrypoint)
 
-        self.log.debug(f"Uploading route to KV store. Payload: {repr(payload)}")
+        self.log.debug("Uploading route to KV store. Payload: %r", payload)
         try:
-            results = await self.kv_client.txn.put(payload=payload)
+            results = await self.consul.txn.put(payload=payload)
             status = 1
             response = ""
         except Exception as e:
@@ -183,7 +194,7 @@ class TraefikConsulProxy(TKvProxy):
 
     async def _kv_atomic_delete_route_parts(self, jupyterhub_routespec, route_keys):
 
-        index, v = await self.kv_client.kv.get(jupyterhub_routespec)
+        index, v = await self.consul.kv.get(jupyterhub_routespec)
         if v is None:
             self.log.warning(
                 "Route %s doesn't exist. Nothing to delete", jupyterhub_routespec
@@ -216,7 +227,7 @@ class TraefikConsulProxy(TKvProxy):
         }})
 
         try:
-            status, response = await self.kv_client.txn.put(payload=payload)
+            status, response = await self.consul.txn.put(payload=payload)
             status = 1
             response = ""
         except Exception as e:
@@ -226,13 +237,13 @@ class TraefikConsulProxy(TKvProxy):
         return status, response
 
     async def _kv_get_target(self, jupyterhub_routespec):
-        _, res = await self.kv_client.kv.get(jupyterhub_routespec)
+        _, res = await self.consul.kv.get(jupyterhub_routespec)
         if res is None:
             return None
         return res["Value"].decode()
 
     async def _kv_get_data(self, target):
-        _, res = await self.kv_client.kv.get(target)
+        _, res = await self.consul.kv.get(target)
 
         if res is None:
             return None
@@ -259,7 +270,7 @@ class TraefikConsulProxy(TKvProxy):
         return routespec, target, data
 
     async def _kv_get_jupyterhub_prefixed_entries(self):
-        routes = await self.kv_client.txn.put(
+        routes = await self.consul.txn.put(
             payload=[
                 {
                     "KV": {

--- a/jupyterhub_traefik_proxy/etcd.py
+++ b/jupyterhub_traefik_proxy/etcd.py
@@ -20,11 +20,10 @@ Route Specification:
 
 from concurrent.futures import ThreadPoolExecutor
 from urllib.parse import urlparse
-import warnings
 
 import escapism
 from tornado.concurrent import run_on_executor
-from traitlets import Any, default, observe, Bool, List, Unicode
+from traitlets import Any, default, Bool, List, Unicode
 
 from .kv_proxy import TKvProxy
 
@@ -97,17 +96,18 @@ class TraefikEtcdProxy(TKvProxy):
         help="Password for accessing etcd.",
     )
 
-    kv_url = Unicode("DEPRECATED", config=True)
-    kv_username = Unicode("DEPRECATED", config=True)
-    kv_password = Unicode("DEPRECATED", config=True)
-
-    @observe("kv_url", "kv_username", "kv_password")
-    def _deprecated_config(self, change):
-        new_name = change.name.replace("kv_", "etcd_")
-        warnings.warn(
-            f"TraefikEtcdProxy.{change.name} is deprecated in 0.4. Use TraefikEtcdProxy.{new_name} = {change.new!r}"
-        )
-        setattr(self, new_name, change.new)
+    kv_url = Unicode("DEPRECATED", config=True).tag(
+        deprecated_in="0.4",
+        deprecated_for="etcd_url",
+    )
+    kv_username = Unicode("DEPRECATED", config=True).tag(
+        deprecated_in="0.4",
+        deprecated_for="etcd_username",
+    )
+    kv_password = Unicode("DEPRECATED", config=True).tag(
+        deprecated_in="0.4",
+        deprecated_for="etcd_password",
+    )
 
     etcd = Any()
 

--- a/jupyterhub_traefik_proxy/kv_proxy.py
+++ b/jupyterhub_traefik_proxy/kv_proxy.py
@@ -22,7 +22,7 @@ import escapism
 import json
 import os
 
-from traitlets import Any, Unicode, default
+from traitlets import Unicode
 from collections.abc import MutableMapping
 
 from . import traefik_utils
@@ -32,49 +32,28 @@ from .proxy import TraefikProxy
 class TKvProxy(TraefikProxy):
     """
     JupyterHub Proxy implementation using traefik and a key-value store.
-    Custom proxy implementations based on trafik and a key-value store
+
+    Custom proxy implementations based on traefik and a key-value store
     can sublass :class:`TKvProxy`.
     """
 
-    kv_client = Any()
-    # Key-value store client
-
-    kv_username = Unicode(
-        config=True, help="""The username for key value store login"""
-    )
-
-    kv_password = Unicode(
-        config=True, help="""The password for key value store login"""
-    )
-
-    kv_url = Unicode(config=True, help="""The URL of the key value store server""")
-
     kv_traefik_prefix = traefik_utils.KVStorePrefix(
+        "traefik",
         config=True,
         help="""The key value store key prefix for traefik static configuration""",
     )
 
-    kv_jupyterhub_prefix = Unicode(
+    kv_jupyterhub_prefix = traefik_utils.KVStorePrefix(
+        "jupyterhub",
         config=True,
         help="""The key value store key prefix for traefik dynamic configuration""",
     )
 
     kv_separator = Unicode(
+        "/",
         config=True,
-        help="""The separator used for the path in the KV store"""
+        help="""The separator used for the path in the KV store""",
     )
-
-    @default("kv_traefik_prefix")
-    def _default_kv_traefik_prefix(self):
-        return "traefik"
-
-    @default("kv_jupyterhub_prefix")
-    def _default_kv_jupyterhub_prefix(self):
-        return "jupyterhub"
-
-    @default("kv_separator")
-    def _default_kv_separator(self):
-        return "/"
 
     def _define_kv_specific_static_config(self):
         """Define the traefik static configuration that configures
@@ -427,5 +406,5 @@ class TKvProxy(TraefikProxy):
                 for n, item in enumerate(v):
                     items.update({ f"{new_key}{sep}{n}" : item })
             else:
-                raise ValueError(f"Cannot upload {v} of type {type(v)} to etcd store")
+                raise ValueError(f"Cannot upload {v} of type {type(v)} to kv store")
         return items

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -79,7 +79,6 @@ class TraefikProxy(Proxy):
     def __init__(self, **kwargs):
         # observe deprecated config names in oauthenticator
         for name, trait in self.class_traits().items():
-            deprecated_in = trait.metadata.get("deprecated_in")
             if trait.metadata.get("deprecated_in"):
                 self.observe(self._deprecated_trait, name)
         super().__init__(**kwargs)

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -273,7 +273,7 @@ class TraefikProxy(Proxy):
             self.traefik_process.wait()
 
     def _start_traefik(self):
-        if self.provider_name not in ("file", "etcd", "consul"):
+        if self.provider_name not in {"file", "etcd", "consul"}:
             raise ValueError(
                 "Configuration mode not supported \n.\
                 The proxy can only be configured through fileprovider, etcd and consul"

--- a/jupyterhub_traefik_proxy/toml.py
+++ b/jupyterhub_traefik_proxy/toml.py
@@ -1,0 +1,16 @@
+
+from traitlets import Unicode
+from .fileprovider import TraefikFileProviderProxy
+
+
+class TraefikTomlProxy(TraefikFileProviderProxy):
+    """Deprecated alias for file provider"""
+    toml_dynamic_config_file = Unicode(
+        config=True,
+    ).tag(
+        deprecated_in="0.4",
+        deprecated_for="TraefikFileProvider.dynamic_config_file",
+    )
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.log.warning("TraefikTomlProxy is deprecated in jupyterhub-traefik-proxy 0.4. Use `c.JupyterHub.proxy_class = 'traefik_file'")

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
             "traefik_consul = jupyterhub_traefik_proxy.consul:TraefikConsulProxy",
             "traefik_etcd = jupyterhub_traefik_proxy.etcd:TraefikEtcdProxy",
             "traefik_file = jupyterhub_traefik_proxy.fileprovider:TraefikFileProviderProxy",
+            "traefik_toml = jupyterhub_traefik_proxy.toml:TraefikTomlProxy",
         ]
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -492,7 +492,7 @@ async def _wait_for_etcd(*etcd_args):
         )
         sys.stdout.write(p.stdout)
         sys.stderr.write(p.stderr)
-        return "is healthy" in p.stdout
+        return "is healthy" in p.stdout + p.stderr
 
     await exponential_backoff(check, "etcd health check", timeout=10)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ async def no_auth_consul_proxy(launch_consul):
     """
     proxy = TraefikConsulProxy(
         public_url=Config.public_url,
-        kv_url=f"http://127.0.0.1:{Config.consul_port}",
+        consul_url=f"http://127.0.0.1:{Config.consul_port}",
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
         check_route_timeout=45,
@@ -106,10 +106,10 @@ async def auth_consul_proxy(launch_consul_acl):
     """
     proxy = TraefikConsulProxy(
         public_url=Config.public_url,
-        kv_url=f"http://127.0.0.1:{Config.consul_port}",
+        consul_url=f"http://127.0.0.1:{Config.consul_port}",
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
-        kv_password=Config.consul_token,
+        consul_password=Config.consul_token,
         check_route_timeout=45,
         should_start=True,
     )
@@ -154,9 +154,9 @@ async def launch_etcd_proxy():
         public_url=Config.public_url,
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
-        kv_url="https://localhost:2379",
-        kv_username="root",
-        kv_password=Config.etcd_password,
+        etcd_url="https://localhost:2379",
+        etcd_username="root",
+        etcd_password=Config.etcd_password,
         etcd_client_ca_cert=f"{config_files}/fake-ca-cert.crt",
         etcd_insecure_skip_verify=True,
         check_route_timeout=45,
@@ -254,7 +254,7 @@ async def external_file_proxy_toml(launch_traefik_file):
 async def external_consul_proxy(launch_consul, configure_consul, launch_traefik_consul):
     proxy = TraefikConsulProxy(
         public_url=Config.public_url,
-        kv_url=f"http://127.0.0.1:{Config.consul_port}",
+        consul_url=f"http://127.0.0.1:{Config.consul_port}",
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
         check_route_timeout=45,
@@ -271,10 +271,10 @@ async def auth_external_consul_proxy(
     print("creating proxy")
     proxy = TraefikConsulProxy(
         public_url=Config.public_url,
-        kv_url=f"http://127.0.0.1:{Config.consul_auth_port}",
+        consul_url=f"http://127.0.0.1:{Config.consul_auth_port}",
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
-        kv_password=Config.consul_token,
+        consul_password=Config.consul_token,
         check_route_timeout=45,
         should_start=False,
     )
@@ -293,7 +293,7 @@ async def external_etcd_proxy(launch_etcd, configure_etcd, launch_traefik_etcd):
     )
     await proxy._wait_for_static_config()
     yield proxy
-    proxy.kv_client.close()
+    proxy.etcd.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,13 +155,13 @@ async def launch_etcd_proxy():
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
         etcd_url="https://localhost:2379",
-        etcd_username="root",
+        etcd_username=Config.etcd_user,
         etcd_password=Config.etcd_password,
         etcd_client_ca_cert=f"{config_files}/fake-ca-cert.crt",
         etcd_insecure_skip_verify=True,
         check_route_timeout=45,
         should_start=True,
-        grpc_options=grpc_options
+        grpc_options=grpc_options,
     )
 
     await proxy.start()
@@ -450,25 +450,28 @@ async def launch_etcd_auth():
         "--listen-client-urls=https://localhost:2379",
         "--advertise-client-urls=https://localhost:2379",
         "--log-level=debug"],
-        close_fds=True
     )
-    await _wait_for_etcd(
+    try:
+        await _wait_for_etcd(
             "--insecure-skip-tls-verify=true",
             "--insecure-transport=false",
             "--debug")
-    yield etcd_proc
-    shutdown_etcd(etcd_proc)
+        yield etcd_proc
+    finally:
+        shutdown_etcd(etcd_proc)
 
 @pytest.fixture
 async def launch_etcd():
     with TemporaryDirectory() as etcd_path:
         etcd_proc = subprocess.Popen(
             ["etcd", "--log-level=debug"],
-            cwd=etcd_path, close_fds=True
+            cwd=etcd_path,
         )
-        await _wait_for_etcd("--debug=true")
-        yield etcd_proc
-        shutdown_etcd(etcd_proc)
+        try:
+            await _wait_for_etcd("--debug=true")
+            yield etcd_proc
+        finally:
+            shutdown_etcd(etcd_proc)
 
 async def _wait_for_etcd(*etcd_args):
     """Etcd may not be ready if we jump straight into the tests.
@@ -478,11 +481,20 @@ async def _wait_for_etcd(*etcd_args):
     In production, etcd would already be running, so don't put this in the
     proxy classes.
     """
-    assert "is healthy" in subprocess.check_output(
-        ["etcdctl", "endpoint", "health", *etcd_args],
-        env=Config.etcdctl_env,
-        stderr=subprocess.STDOUT,
-    ).decode(sys.stdout.encoding)
+
+    def check():
+        p = subprocess.run(
+            ["etcdctl", "endpoint", "health", *etcd_args],
+            env=Config.etcdctl_env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        sys.stdout.write(p.stdout)
+        sys.stderr.write(p.stderr)
+        return "is healthy" in p.stdout
+
+    await exponential_backoff(check, "etcd health check", timeout=10)
 
 
 # @pytest.fixture(scope="function", autouse=True)
@@ -537,7 +549,7 @@ def launch_consul_acl():
                 f"-config-file={config_files}/consul_config.json",
                 "-bootstrap-expect=1",
             ],
-            cwd=consul_path, close_fds=True
+            cwd=consul_path,
         )
         asyncio.run(
             _wait_for_consul(token=Config.consul_token, port=Config.consul_auth_port)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,60 @@
+from traitlets.config import Config
+
+from jupyterhub_traefik_proxy.toml import TraefikTomlProxy
+from jupyterhub_traefik_proxy.etcd import TraefikEtcdProxy
+from jupyterhub_traefik_proxy.consul import TraefikConsulProxy
+
+def test_toml_deprecation(caplog):
+    cfg = Config()
+    cfg.TraefikTomlProxy.toml_static_config_file = 'deprecated-static.toml'
+    cfg.TraefikTomlProxy.toml_dynamic_config_file = 'deprecated-dynamic.toml'
+    p = TraefikTomlProxy(config=cfg)
+    assert p.static_config_file == 'deprecated-static.toml'
+
+    assert p.dynamic_config_file == 'deprecated-dynamic.toml'
+
+    log = '\n'.join([
+        record.msg
+        for record in caplog.records
+    ])
+    assert 'TraefikFileProvider.dynamic_config_file instead' in log
+    assert 'static_config_file instead' in log
+
+def test_etcd_deprecation(caplog):
+    cfg = Config()
+    cfg.TraefikEtcdProxy.kv_url = "http://1.2.3.4:12345"
+    cfg.TraefikEtcdProxy.kv_username = "user"
+    cfg.TraefikEtcdProxy.kv_password = "pass"
+
+    p = TraefikEtcdProxy(config=cfg)
+    assert p.etcd_url=="http://1.2.3.4:12345"
+    assert p.etcd_username == "user"
+    assert p.etcd_password == "pass"
+
+    log = '\n'.join([
+        record.msg
+        for record in caplog.records
+    ])
+    assert 'TraefikEtcdProxy.etcd_url instead' in log
+    assert 'TraefikEtcdProxy.etcd_username instead' in log
+    assert 'TraefikEtcdProxy.etcd_password instead' in log
+
+
+def test_consul_deprecation(caplog):
+    cfg = Config()
+    cfg.TraefikConsulProxy.kv_url = "http://1.2.3.4:12345"
+    cfg.TraefikConsulProxy.kv_username = "user"
+    cfg.TraefikConsulProxy.kv_password = "pass"
+
+    p = TraefikConsulProxy(config=cfg)
+    assert p.consul_url=="http://1.2.3.4:12345"
+    assert p.consul_username == "user"
+    assert p.consul_password == "pass"
+
+    log = '\n'.join([
+        record.msg
+        for record in caplog.records
+    ])
+    assert 'TraefikConsulProxy.consul_url instead' in log
+    assert 'TraefikConsulProxy.consul_username instead' in log
+    assert 'TraefikConsulProxy.consul_password instead' in log


### PR DESCRIPTION
Adds deprecated aliases for the APIs that were removed in #145 

should prevent unnecessary breakage while folks upgrade

closes #149

---

## Deprecations

### TraefikConsulProxy class

- `kv_url` is deprecated, use `consul_url`
- `kv_username` is deprecated, use `consul_username`
- `kv_password` is deprecated, use `consul_password`

### TraefikEtcdProxy class

- `kv_url` is deprecated, use `etcd_url`
- `kv_username` is deprecated, use `etcd_username`
- `kv_password` is deprecated, use `etcd_password`

### TraefikTomlProxy class

- The class is deprecated, use `TraefikFileProviderProxy` instead
- `toml_dynamic_config_file` is deprecated, use `dynamic_config_file` instead. YAML is also supported.

### TraefikProxy class (all classes)

- `toml_static_config_file` is deprecated, use `static_config_file`. YAML is also supported.
