### PR TITLE
Improve performance, scaling

### DIFF
--- a/jupyterhub_traefik_proxy/fileprovider.py
+++ b/jupyterhub_traefik_proxy/fileprovider.py
@@ -218,7 +218,8 @@ class TraefikFileProviderProxy(TraefikProxy):
                 )
                 raise
         try:
-            await self._wait_for_route(traefik_routespec)
+            async with self.semaphore:
+                await self._wait_for_route(traefik_routespec)
         except TimeoutError:
             self.log.error(
                 f"Is Traefik configured to watch {self.dynamic_config_file}?"

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -107,6 +107,20 @@ class TraefikProxy(Proxy):
     static_config = Dict()
     dynamic_config = Dict()
 
+    traefik_providers_throttle_duration = Unicode(
+        "0s",
+        config=True,
+        help="""
+            throttle traefik reloads of configuration.
+
+            When traefik sees a change in configuration,
+            it will wait this long before applying the next one.
+            This affects how long adding a user to the proxy will take.
+
+            See https://doc.traefik.io/traefik/providers/overview/#providersprovidersthrottleduration
+            """,
+    )
+
     traefik_api_url = Unicode(
         "http://localhost:8099",
         config=True,
@@ -371,6 +385,9 @@ class TraefikProxy(Proxy):
         Subclasses should specify any traefik providers themselves, in
         :attrib:`self.static_config["providers"]`
         """
+        self.static_config["providers"][
+            "providersThrottleDuration"
+        ] = self.traefik_providers_throttle_duration
 
         if self.traefik_log_level:
             self.static_config["log"] = {"level": self.traefik_log_level}

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -288,6 +288,7 @@ class TraefikProxy(Proxy):
         await exponential_backoff(
             _check_traefik_dynamic_conf_ready,
             f"Traefik route for {routespec} configuration not available",
+            scale_factor=1.2,
             timeout=self.check_route_timeout,
         )
 


### PR DESCRIPTION
- limit concurrency of API requests, fixes timeouts running perf tests
- check for specific endpoints with traefik API instead of getting them all
- reduce exponential-backoff scale factor for slightly quicker retries
- add traefik_providers_throttle_duration to set traefik.providersThrottleDuration, and set the default to 0s for maximum responsiveness, which drastically improves perceived performance