### PR TITLE
Fix handling of empty dicts in traefik config

### DIFF
--- a/jupyterhub_traefik_proxy/fileprovider.py
+++ b/jupyterhub_traefik_proxy/fileprovider.py
@@ -66,11 +66,14 @@ class TraefikFileProviderProxy(TraefikProxy):
         except FileNotFoundError:
             dynamic_config = {}
 
-        if not dynamic_config:
-            dynamic_config = {
-                "http": {"services": {}, "routers": {}},
-                "jupyter": {"routers": {}},
-            }
+        # fill in default keys
+        # use setdefault to ensure these are always fully defined
+        # and never _partially_ defined
+        http = dynamic_config.setdefault("http", {})
+        http.setdefault("services", {})
+        http.setdefault("routers", {})
+        jupyter = dynamic_config.setdefault("jupyter", {})
+        jupyter.setdefault("routers", {})
         return dynamic_config
 
     def persist_dynamic_config(self):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -194,6 +194,10 @@ def test_default_port():
                 "other.host/path/no/slash/abc/",
             ],
         ),
+        (
+            "/one/",
+            [],
+        ),
     ],
 )
 async def test_add_get_delete(
@@ -340,6 +344,10 @@ async def test_add_get_delete(
 
 
 async def test_get_all_routes(proxy, launch_backend):
+    # initial state: no routes
+    routes = await proxy.get_all_routes()
+    assert routes == {}
+
     routespecs = ["/proxy/path1", "/proxy/path2/", "/proxy/path3/"]
     targets = [
         "http://127.0.0.1:9900",
@@ -387,6 +395,11 @@ async def test_get_all_routes(proxy, launch_backend):
         pass
 
     assert_equal(routes, expected_output)
+
+    for routespec in routespecs:
+        await proxy.delete_route(routespec)
+    routes = await proxy.get_all_routes()
+    assert routes == {}
 
 
 async def test_host_origin_headers(proxy, launch_backend):


### PR DESCRIPTION
dynamic config was popping empty dicts from dynamic config due to a bug in traefik that balks at empty dicts, but several places in code still assumed these dicts to be present.

This fixes things to be simpler by avoiding _writing_ the empty config, but always ensuring that they are defined in the local `self.dynamic_config`.

It also fixes dict merges in setup dynamic config to be deep merges, instead of clobbering what was there before.

Test coverage is added to ensure we handle the case that wasn't working - mainly deleting the last route

closes #171 