### PR TITLE
docs: update link to traefik API

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ source_suffix = [".md", ".rst"]
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/consul.md
+++ b/docs/source/consul.md
@@ -13,7 +13,7 @@ e.g. with multiple traefik-proxy instances.
 5. Install **traefik**
 6. Install **consul**
 
-- You can find the full installation guide and examples in the [Introduction section](install.html#traefik-proxy-installation)
+- You can find the full installation guide and examples in the [installation section](install)
 
 ## How-To enable TraefikConsulProxy
 

--- a/docs/source/etcd.md
+++ b/docs/source/etcd.md
@@ -13,7 +13,7 @@ e.g. with multiple traefik-proxy instances.
 5. Install **traefik**
 6. Install **etcd**
 
-- You can find the full installation guide and examples in the [Introduction section](install.html#traefik-proxy-installation)
+- You can find the full installation guide and examples in the [installation section](install)
 
 ## How-To enable TraefikEtcdProxy
 

--- a/docs/source/file.md
+++ b/docs/source/file.md
@@ -9,7 +9,7 @@
 2. Install **jupyterhub-traefik-proxy**
 3. Install **traefik**
 
-- You can find the full installation guide and examples in the [Introduction section](install.html#traefik-proxy-installation)
+- You can find the full installation guide and examples in the [installation section](install)
 
 ## How-To enable TraefikFileProviderProxy
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -107,9 +107,9 @@ c.JupyterHub.proxy_class = "traefik_consul"
 
 ## Implementation details
 
-1. **Traefik Dashboard**
+1. **Traefik API**
 
-   Traefik provides a Web UI **dashboard** where you can see the frontends and backends registered, the routing rules, some metrics, but also other configuration elements. Find out more about traefik api's, [here](https://docs.traefik.io/configuration/api/#security).
+   traefik-proxy uses the [Traefik API](https://docs.traefik.io/configuration/api/) to monitor routes and configurations.
 
    Because of **security** concerns, in traefik-proxy implementation, traefik api endpoint isn't exposed on the public http endpoint. Instead, it runs on a dedicated **authenticated endpoint** that's on localhost by default.
 
@@ -121,8 +121,7 @@ c.JupyterHub.proxy_class = "traefik_consul"
    c.TraefikFileProviderProxy.traefik_api_username = "admin"
    ```
 
-   Check out TraefikProxy's **API Reference** for more configuration options.
-   <br/><br/>
+   Check out TraefikProxy's [API Reference](TraefikProxy) for more configuration options.
 
 2. **TKvProxy class**
 

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -109,7 +109,7 @@ c.JupyterHub.proxy_class = "traefik_consul"
 
 1. **Traefik API**
 
-   traefik-proxy uses the [Traefik API](https://docs.traefik.io/configuration/api/) to monitor routes and configurations.
+   traefik-proxy uses the [Traefik API](https://doc.traefik.io/traefik/operations/api/) to monitor routes and configurations.
 
    Because of **security** concerns, in traefik-proxy implementation, traefik api endpoint isn't exposed on the public http endpoint. Instead, it runs on a dedicated **authenticated endpoint** that's on localhost by default.
 


### PR DESCRIPTION
instead of referencing the unused dashboard, suggested by @GeorgianaElena in https://github.com/jupyterhub/traefik-proxy/pull/162#issuecomment-1443423910

and fix a couple broken doc links and sphinx warnings