### PR TITLE
test: fix consul auth port

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ async def auth_consul_proxy(launch_consul_auth):
     """
     proxy = TraefikConsulProxy(
         public_url=Config.public_url,
-        consul_url=f"http://127.0.0.1:{Config.consul_port}",
+        consul_url=f"http://127.0.0.1:{Config.consul_auth_port}",
         traefik_api_password=Config.traefik_api_pass,
         traefik_api_username=Config.traefik_api_user,
         consul_password=Config.consul_token,


### PR DESCRIPTION
Some of the consul tests were running with the wrong consul port.

This worked on CI because consul is a module-level fixture, so the tests ran against the unauthenticated consul (authenticated requests to consul without auth still succeed), but wouldn't work when running subsets of tests that excluded the unauthenticated consul fixture.