### PR TITLE
use editable install to get test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install --upgrade setuptools pip
-          pip install -r dev-requirements.txt --upgrade .
+          pip install -r dev-requirements.txt -e .
           python -m jupyterhub_traefik_proxy.install --output=./bin
 
           pip freeze


### PR DESCRIPTION
pytest-cov doesn't find coverage of installed files

We'll see what the report looks like, but I think this closes #66