### PR TITLE
set providersThrottleDuration=0s in tests

### DIFF
--- a/tests/config_files/traefik.toml
+++ b/tests/config_files/traefik.toml
@@ -2,10 +2,9 @@
  level = "debug"
 
 [api]
- dashboard = true
 
-[wss]
- protocol = "http"
+[providers]
+providersThrottleDuration = "0s"
 
 [providers.file]
  directory = "./tests/config_files/dynamic_config"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,6 +338,7 @@ def _launch_traefik_cli(*extra_args, env=None):
     default_args = (
         "--api",
         "--log.level=debug",
+        "--providers.providersThrottleDuration=0s",
         # "--entrypoints.web.address=:8000",
         "--entrypoints.websecure.address=:8000",
         "--entrypoints.enter_api.address=:8099",


### PR DESCRIPTION
affects all 'external' tests, matches config when running with should_start=True

also remove unused wss, dashboard config