### PR TITLE
Revert some entrypoint names in docs, renumber how to install steps

### DIFF
--- a/docs/source/consul.md
+++ b/docs/source/consul.md
@@ -14,10 +14,10 @@ e.g. with multiple traefik-proxy instances.
 
 ## How-To install TraefikConsulProxy
 
-3. Install **jupyterhub**
-4. Install **jupyterhub-traefik-proxy**
-5. Install **traefik**
-6. Install **consul**
+1. Install **jupyterhub**
+2. Install **jupyterhub-traefik-proxy**
+3. Install **traefik**
+4. Install **consul**
 
 - You can find the full installation guide and examples in the [installation section](install)
 

--- a/docs/source/consul.md
+++ b/docs/source/consul.md
@@ -157,7 +157,7 @@ If TraefikConsulProxy is used as an externally managed service, then make sure y
     [api]
 
     # the public port where traefik accepts http requests
-    [entryPoints.web]
+    [entryPoints.http]
     address = ":8000"
 
     # the port on localhost where the traefik api should be found
@@ -233,7 +233,7 @@ This is an example setup for using JupyterHub and TraefikConsulProxy managed by 
    [api]
 
    # the public port where traefik accepts http requests
-   [entryPoints.web]
+   [entryPoints.http]
    address = ":8000"
 
    # the port on localhost where the traefik api should be found

--- a/docs/source/etcd.md
+++ b/docs/source/etcd.md
@@ -8,10 +8,10 @@ e.g. with multiple traefik-proxy instances.
 
 ## How-To install TraefikEtcdProxy
 
-3. Install **jupyterhub**
-4. Install **jupyterhub-traefik-proxy**
-5. Install **traefik**
-6. Install **etcd**
+1. Install **jupyterhub**
+2. Install **jupyterhub-traefik-proxy**
+3. Install **traefik**
+4. Install **etcd**
 
 - You can find the full installation guide and examples in the [installation section](install)
 

--- a/docs/source/etcd.md
+++ b/docs/source/etcd.md
@@ -229,7 +229,7 @@ This is an example setup for using JupyterHub and TraefikEtcdProxy managed by an
    [api]
 
    # the public port where traefik accepts http requests
-   [entryPoints.web]
+   [entryPoints.http]
    address = ":8000"
 
    # the port on localhost where the traefik api should be found

--- a/docs/source/file.md
+++ b/docs/source/file.md
@@ -183,7 +183,7 @@ This is an example setup for using JupyterHub and TraefikFileProviderProxy manag
    [api]
 
    # the public port where traefik accepts http requests
-   [entryPoints.web]
+   [entryPoints.http]
    address = ":8000"
 
    # the port on localhost where the traefik api should be found


### PR DESCRIPTION
In #192 the previous entrypoint names were restored in many places but I think they weren't updated everywhere in the docs, this changes `web` back to `http` in the example configs.  The numbering for steps in the how to install part of the etcd and consul docs started at 3 instead of 1 and this changes that also.