### PR TITLE
make sure that `/prefix` and `/prefix/` are handled the same

### DIFF
--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -23,7 +23,8 @@ class KVStorePrefix(Unicode):
 
 def generate_rule(routespec):
     # validate assumption that routespecs always end with '/'
-    assert routespec.endswith("/")
+    if not routespec.endswith("/"):
+        raise ValueError("routespec must end with /")
     routespec = unquote(routespec)
 
     # traefik won't match /proxy/path to /proxy/path/

--- a/jupyterhub_traefik_proxy/traefik_utils.py
+++ b/jupyterhub_traefik_proxy/traefik_utils.py
@@ -22,6 +22,18 @@ class KVStorePrefix(Unicode):
 
 
 def generate_rule(routespec):
+    """Generate a traefik routing rule for a jupyterhub routespec
+
+
+    - if a routespec doesn't start with a `/`, the first part is a hostname.
+    - routespecs always end with `/`
+    - routespecs are a path _prefix_, and should match anything under them
+    - the root of the route without the trailing slash should match the rule,
+      e.g. the routespec `/prefix/` should match `/prefix` and `/prefix/tree`
+
+    Traefik rule documentation: https://doc.traefik.io/traefik/routing/routers/#rule
+    """
+
     # validate assumption that routespecs always end with '/'
     if not routespec.endswith("/"):
         raise ValueError("routespec must end with /")

--- a/tests/test_traefik_utils.py
+++ b/tests/test_traefik_utils.py
@@ -76,3 +76,20 @@ def test_atomic_writing_recovery(tmpdir):
 
     # didn't leave any residue
     assert tmpdir.listdir() == [testfile]
+
+
+@pytest.mark.parametrize(
+    "routespec, expected_rule",
+    [
+        ("/", "PathPrefix(`/`)"),
+        ("/path/prefix/", "( PathPrefix(`/path/prefix/`) || Path(`/path/prefix`) )"),
+        ("host/", "Host(`host`) && PathPrefix(`/`)"),
+        (
+            "host/path/prefix/",
+            "Host(`host`) && ( PathPrefix(`/path/prefix/`) || Path(`/path/prefix`) )",
+        ),
+    ],
+)
+def test_generate_rule(routespec, expected_rule):
+    rule = traefik_utils.generate_rule(routespec)
+    assert rule == expected_rule

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,18 +58,20 @@ async def check_host_up_http(url):
 async def get_responding_backend_port(traefik_url, path):
     """Check if traefik followed the configuration and routed the
     request to the right backend"""
-    if not path.endswith("/"):
-        path += "/"
+
+    headers = {}
 
     if not path.startswith("/"):
-        req = HTTPRequest(
-            traefik_url + "".join("/" + path.split("/", 1)[1]),
-            method="GET",
-            headers={"Host": path.split("/")[0]},
-            validate_cert=False,
-        )
-    else:
-        req = HTTPRequest(traefik_url + path, validate_cert=False)
+        host, slash, path = path.partition("/")
+        path = slash + path
+        headers["Host"] = host
+
+    req = HTTPRequest(
+        traefik_url + path,
+        headers=headers,
+        validate_cert=False,
+        follow_redirects=True,
+    )
 
     try:
         resp = await AsyncHTTPClient().fetch(req)


### PR DESCRIPTION
adds Path(/prefix) rule to PathPrefix(/prefix/) so that we don't get redirect loops on /prefix

I believe this closes #195 