### PR TITLE
ensure requirements.txt is included in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include jupyterhub_traefik_proxy/_version.py
+include requirements.txt


### PR DESCRIPTION
Congrats on 1.0.0! 

Noted on the [conda-forge WIP PR](https://github.com/conda-forge/staged-recipes/pull/22853), this ensures the `requirements.txt` is included in the PyPI `.tar.gz`.

of course, any of the following would be welcome over there:
- review
- insights on how we might test this beast
- co-maintainers (or a nod to add `@conda-forge/jupyterhub`) :P
- bounding the `traefik` dependency?
  - maybe a CLI check?
- thoughts about improving the formal metadata for optional runtime (hard test time) deps of `python-consul2`, `etcdpy`, `ruamel.yaml`... 
  - extras? (bleah)
  - more subpackages/monorepo?
  - maybe making some of the options behind `ImportError` guards in `conftest.py`, so we could at least `-k` down to something reasonable?