### PR TITLE
add TraefikProxy.enable_setup_dynamic_config for opt-out of dynamic config setup

### DIFF
--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -91,17 +91,18 @@ class TraefikProxy(Proxy):
         config=True,
         help="""
         Whether to initialize the traefik dynamic configuration
-        from JupyterHub configuration.
+        from JupyterHub configuration, when should_start is False
+        (dynamic configuration is always applied when should_start is True).
 
         Creates the traefik API router and TLS setup, if any.
         When True, only traefik static configuration must be managed by the external service
         (configuration of the endpoints and provider).
+        The traefik api router should not already be configured via other dynamic configuration providers.
 
-        When False, initial dynamic configuration must be handled externally,
+        When False, initial dynamic configuration must be handled externally
         and match TraefikProxy configuration, such as `traefik_api_url`,
         traefik_api_username` and `traefik_api_password`.
-
-        Only used when should_start is False.
+        Choose this if the traefik api router is already configured via dynamic configuration elsewhere.
 
         .. versionadded:: 1.1
         """,

--- a/jupyterhub_traefik_proxy/proxy.py
+++ b/jupyterhub_traefik_proxy/proxy.py
@@ -75,13 +75,35 @@ class TraefikProxy(Proxy):
         Has no effect if `Proxy.should_start` is False.
         """,
     )
+
     extra_dynamic_config = Dict(
         config=True,
         help="""Extra dynamic configuration for treafik.
 
         Merged with the default dynamic config during startup.
 
-        Always takes effect.
+        Always takes effect unless should_start and enable_setup_dynamic_config are both False.
+        """,
+    )
+
+    enable_setup_dynamic_config = Bool(
+        True,
+        config=True,
+        help="""
+        Whether to initialize the traefik dynamic configuration
+        from JupyterHub configuration.
+
+        Creates the traefik API router and TLS setup, if any.
+        When True, only traefik static configuration must be managed by the external service
+        (configuration of the endpoints and provider).
+
+        When False, initial dynamic configuration must be handled externally,
+        and match TraefikProxy configuration, such as `traefik_api_url`,
+        traefik_api_username` and `traefik_api_password`.
+
+        Only used when should_start is False.
+
+        .. versionadded:: 1.1
         """,
     )
 
@@ -554,7 +576,13 @@ class TraefikProxy(Proxy):
 
         Ensures dynamic config is setup and static config is loaded
         """
-        await self._setup_traefik_dynamic_config()
+        if self.enable_setup_dynamic_config:
+            await self._setup_traefik_dynamic_config()
+        else:
+            self.log.info(
+                "Assuming traefik dynamic configuration for API at %s is set up already.",
+                self.traefik_api_url,
+            )
         await self._wait_for_static_config()
         self._start_future = None
 


### PR DESCRIPTION
allows externally managed proxies to take control of setting up the api router, tls, etc.

Mostly for cases where traefik is used for more than one service, not just JupyterHub, or the generated dynamic config wouldn't be correct.

Addresses https://github.com/jupyterhub/traefik-proxy/commit/83f226062e7752063a5377ff2bba0a1897693070#r115107132

What do you think, @alexleach?
