### PR TITLE
express yaml optional dependency

### DIFF
--- a/docs/source/file.md
+++ b/docs/source/file.md
@@ -75,6 +75,15 @@ will be managed by JupyterHub. This allows e.g., the administrator to configure 
 
 ```
 
+````{note}
+yaml support requires the `ruamel.yaml` package, which you can install directly, or with:
+
+```
+pip install jupyterhub-traefik-proxy[yaml]
+```
+
+````
+
 ## Externally managed TraefikFileProviderProxy
 
 When TraefikFileProviderProxy is externally managed, service managers like [systemd](https://www.freedesktop.org/wiki/Software/systemd/)

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ setup(
         # see https://github.com/jupyterhub/traefik-proxy/issues/155 for more
         "consul": ["python-consul2"],
         "etcd": ["etcdpy"],
+        "yaml": ["ruamel.yaml"],
         "test": [
-            "jupyterhub-traefik-proxy[redis,etcd,consul]",
+            "jupyterhub-traefik-proxy[redis,etcd,consul,yaml]",
             "certipy",
             "notebook>=4.0",
             "pytest",


### PR DESCRIPTION
previously implicit with informative error message

now explicit, documented, and available as `jupyterhub-traefik-proxy[yaml]`