### PR TITLE
fix initial cursor in delete script

### DIFF
--- a/jupyterhub_traefik_proxy/redis.py
+++ b/jupyterhub_traefik_proxy/redis.py
@@ -136,32 +136,6 @@ class TraefikRedisProxy(TKvProxy):
         """
         return self.redis.register_script(_delete_lua)
 
-    @default("_delete_script_2")
-    def _register_delete_script_2(self):
-        """Register LUA script for deleting all keys matching in a prefix
-
-        Doing the scan & delete from Python is _extremely_ slow
-        for some reason
-        """
-        _delete_lua = """
-        local all_keys = {};
-        for pattern in ARGV do
-            local cursor = "0";
-            repeat
-                local result = redis.call("SCAN", cursor, "match", ARGV[1], "count", 100)
-                cursor = result[1];
-                for i, key in ipairs(result[2]) do
-                    table.insert(all_keys, key);
-                end
-            until cursor == "0"
-        end
-        for i, key in ipairs(all_keys) do
-            redis.call("DEL", key);
-        end
-        return #all_keys;
-        """
-        return self.redis.register_script(_delete_lua)
-
     async def _kv_atomic_delete(self, *keys):
         """Delete one or more keys
 

--- a/jupyterhub_traefik_proxy/redis.py
+++ b/jupyterhub_traefik_proxy/redis.py
@@ -70,7 +70,12 @@ class TraefikRedisProxy(TKvProxy):
         f = super()._cleanup()
         if f is not None:
             await f
-        await self.redis.close()
+        if hasattr(self.redis, 'aclose'):
+            aclose = self.redis.aclose
+        else:
+            # redis < 5.0.1
+            aclose = self.redis.close
+        await aclose()
 
     def _setup_traefik_static_config(self):
         self.log.debug("Setting up the redis provider in the traefik static config")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,6 +418,7 @@ async def external_redis_proxy(launch_traefik_redis, proxy_args):
     )
     await proxy._start_future
     yield proxy
+    await proxy._cleanup()
 
 
 @pytest.fixture
@@ -801,6 +802,7 @@ async def _wait_for_redis():
     from redis.asyncio import Redis
 
     async def _check_redis():
+        r = None
         try:
             r = Redis(
                 port=Config.redis_port,
@@ -811,6 +813,10 @@ async def _wait_for_redis():
         except redis.exceptions.ConnectionError as e:
             print(e)
             return False
+        finally:
+            if r is not None:
+                await r.aclose()
+
         return True
 
     await exponential_backoff(


### PR DESCRIPTION
empty string is not a valid cursor in latest redis-server (seems valid in 7.2.5, not 7.4, but not 100% sure), unclear if it ever should have been.

repeat...until always executes block at least once, so didn't need the empty string to not match the `until` condition.

logging closure fixed as well

closes #252 