### PR TITLE
Update Docs on setting up https

### DIFF
--- a/docs/source/https.md
+++ b/docs/source/https.md
@@ -115,6 +115,7 @@ c.TraefikProxy.extra_static_config = {
             "address": ":80"
         },
         "https": {
+            "address": ":443",
             "http": {
                 "tls": {
                     "options": "default"
@@ -127,8 +128,8 @@ c.TraefikProxy.extra_static_config = {
             "acme": {
                 "email": "you@example.com",
                 "storage": "acme.json",
+                "tlsChallenge": {},
             },
-            "tlsChallenge": {},
         },
     },
 }


### PR DESCRIPTION
We had issues using the docs for setting up traefik. As a result I propose two changes:

- tlsChallenge is part of the acme setting: https://doc.traefik.io/traefik/https/acme/#tlschallenge
- Additionally I'd expect a traefik with tls to listen on 443