### PR TITLE
add missing example redis config

### DIFF
--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -96,7 +96,7 @@ you can load a specific config file and start JupyterHub using:
 $ jupyterhub -f /path/to/jupyterhub_config.py
 ```
 
-There is an example configuration file [here](https://github.com/jupyterhub/traefik-proxy/blob/HEAD/examples/jupyterhub_config_toml.py) that configures JupyterHub to run with [TraefikRedisProxy](redis) as the proxy and uses dummyauthenticator and simplespawner to enable testing without administrative privileges.
+There is an example configuration file [here](https://github.com/jupyterhub/traefik-proxy/blob/HEAD/examples/jupyterhub_config_redis.py) that configures JupyterHub to run with [TraefikRedisProxy](redis) as the proxy and uses dummyauthenticator and simplespawner to enable testing without administrative privileges.
 
 In _jupyterhub_config.py_:
 

--- a/examples/jupyterhub_config_redis.py
+++ b/examples/jupyterhub_config_redis.py
@@ -1,6 +1,6 @@
 """sample jupyterhub config file for testing
 
-configures jupyterhub to run with traefik and etcd.
+configures jupyterhub to run with traefik and redis.
 
 configures jupyterhub with dummyauthenticator and simplespawner
 to enable testing without administrative privileges.
@@ -8,9 +8,9 @@ to enable testing without administrative privileges.
 
 c = get_config()  # noqa
 
-c.JupyterHub.proxy_class = "traefik_etcd"
-c.TraefikEtcdProxy.traefik_api_username = "admin"
-c.TraefikEtcdProxy.traefik_api_password = "admin"
+c.JupyterHub.proxy_class = "traefik_redis"
+c.TraefikProxy.traefik_api_username = "admin"
+c.TraefikProxy.traefik_api_password = "admin"
 
 # use dummy and simple auth/spawner for testing
 c.JupyterHub.authenticator_class = "dummy"

--- a/examples/jupyterhub_config_toml.py
+++ b/examples/jupyterhub_config_toml.py
@@ -4,8 +4,6 @@ configures jupyterhub to run with traefik_file.
 
 configures jupyterhub with dummyauthenticator and simplespawner
 to enable testing without administrative privileges.
-
-requires jupyterhub 1.0.dev
 """
 
 c = get_config()  # noqa
@@ -18,3 +16,4 @@ c.TraefikFileProviderProxy.traefik_log_level = "INFO"
 # use dummy and simple auth/spawner for testing
 c.JupyterHub.authenticator_class = "dummy"
 c.JupyterHub.spawner_class = "simple"
+c.JupyterHub.ip = "127.0.0.1"


### PR DESCRIPTION
and restores link to it (reverts #260)

had this file sitting around already, I apparently missed a `git add` when I added the link, but never cleaned it up.

Updates other examples to

- remove outdated reference to jupyterhub 1.0dev
- listen on localhost when running with dummy auth for testing