### PR TITLE
update tests for websockets 14, python 3.13 ssl

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,11 @@ def client_ca(certipy):
         # self.internal_ssl_cert,
         # cafile=self.internal_ssl_ca,
     )
+    # FIXME: generate certs with Authority Key defined for strict checking
+    # upstream PR: https://github.com/LLNL/certipy/pull/23/
+    # avoids Missing Authority Key Identifier SSL errors
+    # with new defaults in Python 3.13
+    ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
     AsyncHTTPClient.configure(None, defaults={"ssl_options": ssl_context})
     return record['files']['ca']
 
@@ -311,6 +316,8 @@ def _check_ssl(proxy, client_ca):
     )
     context.check_hostname = True
     context.verify_mode = ssl.VerifyMode.CERT_REQUIRED
+    # required for Python 3.13 until we get a certipy update
+    context.verify_flags &= ~ssl.VERIFY_X509_STRICT
     context.load_cert_chain(proxy.ssl_cert, proxy.ssl_key)
 
     url = urlparse(Config.public_url)

--- a/tests/dummy_http_server.py
+++ b/tests/dummy_http_server.py
@@ -13,30 +13,37 @@ from http import HTTPStatus
 import websockets
 
 
-async def process_request(path, request_headers, port):
-    if path.endswith("/ws"):
+async def process_request(connection, request, port):
+    if request.path.endswith("/ws"):
         return None
     headers = {
         "Content-Type": "text/plain",
-        "Host": request_headers.get("Host", "None"),
-        "Origin": request_headers.get("Origin", "None"),
+        "Host": request.headers.get("Host", "None"),
+        "Origin": request.headers.get("Origin", "None"),
     }
-    return (HTTPStatus.OK, headers, str(port).encode("utf8"))
+    return connection.respond(HTTPStatus.OK, headers, str(port).encode("utf8"))
 
 
-async def send_port(websocket, path):
-    await websocket.send(str(websocket.port))
+async def send_port(websocket):
+    _ip, port = websocket.local_address
+    await websocket.send(str(port))
 
 
-async def main(port):
+async def main(port, *, _start_future=None, _stop_future=None):
+    # allow signaling a stop (in tests)
+    if _stop_future is None:
+        _stop_future = asyncio.Future()
+
     async with websockets.serve(
         send_port,
         host="127.0.0.1",
         port=port,
         process_request=partial(process_request, port=port),
     ):
+        if _start_future:
+            _start_future.set_result(None)
         # wait forever
-        await asyncio.Future()
+        await _stop_future
 
 
 if __name__ == "__main__":

--- a/tests/test_dummy_http_server.py
+++ b/tests/test_dummy_http_server.py
@@ -1,0 +1,32 @@
+import asyncio
+import sys
+
+import pytest
+import websockets
+
+from .dummy_http_server import main
+
+
+# quick test that the dummy http server for tests works!
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="websockets require Python 3.9")
+async def test_dummy_server():
+    port = 5678
+    start_future = asyncio.Future()
+    stop_future = asyncio.Future()
+    req_url = f"ws://127.0.0.1:{port}/ws"
+    main_future = asyncio.ensure_future(
+        main(port, _start_future=start_future, _stop_future=stop_future)
+    )
+    await asyncio.wait(
+        [start_future, main_future], timeout=5, return_when=asyncio.FIRST_COMPLETED
+    )
+    if main_future.done():
+        main_future.result()
+    async with websockets.connect(req_url) as websocket:
+        ws_port = await websocket.recv()
+    assert ws_port == str(port)
+    stop_future.cancel()
+    try:
+        await main_future
+    except asyncio.CancelledError:
+        pass

--- a/tests/test_dummy_http_server.py
+++ b/tests/test_dummy_http_server.py
@@ -1,19 +1,17 @@
 import asyncio
-import sys
 
-import pytest
 import websockets
+from tornado.httpclient import AsyncHTTPClient
 
 from .dummy_http_server import main
 
 
 # quick test that the dummy http server for tests works!
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="websockets require Python 3.9")
-async def test_dummy_server():
+async def test_dummy_server(request):
     port = 5678
     start_future = asyncio.Future()
     stop_future = asyncio.Future()
-    req_url = f"ws://127.0.0.1:{port}/ws"
+    # stat dummy server, wait for it to start
     main_future = asyncio.ensure_future(
         main(port, _start_future=start_future, _stop_future=stop_future)
     )
@@ -22,11 +20,21 @@ async def test_dummy_server():
     )
     if main_future.done():
         main_future.result()
-    async with websockets.connect(req_url) as websocket:
-        ws_port = await websocket.recv()
-    assert ws_port == str(port)
-    stop_future.cancel()
+
     try:
-        await main_future
-    except asyncio.CancelledError:
-        pass
+        http_url = f"http://127.0.0.1:{port}/test"
+        ws_url = f"ws://127.0.0.1:{port}/ws"
+        resp = await AsyncHTTPClient().fetch(http_url)
+        assert resp.body == str(port).encode()
+
+        ws_url = f"ws://127.0.0.1:{port}/ws"
+
+        async with websockets.connect(ws_url) as websocket:
+            ws_port = await websocket.recv()
+        assert ws_port == str(port)
+    finally:
+        stop_future.cancel()
+        try:
+            await main_future
+        except asyncio.CancelledError:
+            pass

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -499,6 +499,7 @@ async def test_check_routes(proxy, username):
     assert_equal(before, after)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="websockets require Python 3.9")
 async def test_websockets(proxy, launch_backends):
     routespec = "/user/username/"
     data = {}

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -499,7 +499,6 @@ async def test_check_routes(proxy, username):
     assert_equal(before, after)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="websockets require Python 3.9")
 async def test_websockets(proxy, launch_backends):
     routespec = "/user/username/"
     data = {}


### PR DESCRIPTION
websockets tests now require Python 3.9 to avoid dealing with the API change

closes #264