### PR TITLE
allow explicit traefik_api_hashed_password, use bcrypt for hash instead of md5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp
+bcrypt
 escapism
 jupyterhub>=0.9
-passlib
 toml


### PR DESCRIPTION
use bcrypt instead of md5, which is deprecated and forbidden by FIPS, and the `passlib` api we were using calls a deprecated methods slated for removal in Python 3.13.

allows users to set `traefik_api_hashed_password` via config to pick appropriate hashing if they don't want our default

closes #266 